### PR TITLE
Minimal fix

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,7 +21,7 @@
             "inherits" : "default",
             "cacheVariables": {
                 "ENABLE_CODE_COVERAGE" : "ON",
-                "CLLTK_EXAMPLES": "OFF"
+                "CLLTK_EXAMPLES": "ON"
             }
         },
         {

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,8 @@
-1.2.42
+1.2.43
 
 # Change log
+## 1.2.43
+- make tracing thread safe
 ## 1.2.41
 - fix potential memory leak in snapshot
 ## 1.2.40

--- a/examples/complex_c/complex_c.c
+++ b/examples/complex_c/complex_c.c
@@ -87,7 +87,7 @@ void macro_as_tracebuffer_name(void)
 
 void dynamic_tracing(void)
 {
-	clltk_dynamic_tracebuffer_creation("SIMPLE_C_dyn", 1);
+	clltk_dynamic_tracebuffer_creation("SIMPLE_C_dyn", 1024);
 	clltk_dynamic_tracepoint_execution("SIMPLE_C_dyn", __FILE__, __LINE__, 0, 0,
 									   "dynamic tracepoint with two args %s %lu", "arg0", 10lu);
 }

--- a/scripts/userspace/run.sh
+++ b/scripts/userspace/run.sh
@@ -15,14 +15,14 @@ cd ${ROOT_PATH}
 
 BUILD_DIR=${BUILD_DIR:-./build/}
 BUILD_DIR=$(realpath $BUILD_DIR)/
-echo BUILD_DIR="$BUILD_DIR"
+echo "BUILD_DIR = \"$BUILD_DIR\""
 
 EXE_NAME=$1
 shift
 EXE_ARGS=$*
 
-FOUND_FILE=$(find $BUILD_DIR -type f -executable -name "$EXE_NAME" -print -quit)
-echo FOUND_FILE = $FOUND_FILE
+FOUND_FILE=$(find $BUILD_DIR -path "${BUILD_DIR}in_container" -prune -o -type f -executable -name "$EXE_NAME" -print -quit)
+echo "FOUND_FILE = \"$FOUND_FILE\""
 
 if [[ -z "${CLLTK_TRACING_PATH}" ]] ; then
     mkdir -p /tmp/traces

--- a/snapshot_library/source/file.hpp
+++ b/snapshot_library/source/file.hpp
@@ -28,7 +28,6 @@ struct File {
 	const std::string &getFilepath(void) const { return filepath; }
 	const struct stat &getFilStatus(void) const { return status; }
 	size_t getFilSize(void) const { return status.st_size; }
-	const void *const getContent(void) const { return content; }
 
   protected:
 	std::string filepath;

--- a/tests/python_tests/helper/build_temp_target.py
+++ b/tests/python_tests/helper/build_temp_target.py
@@ -74,7 +74,7 @@ def process(file_content, build_musst_fail=False, run_musst_fail=False, runs=1, 
     except RuntimeError as e:
         if run_musst_fail:
             tmp.cleanup()
-            return None
+            return e.args[0]
         else:
             raise e
     if run_musst_fail:

--- a/tests/python_tests/system_tests.py
+++ b/tests/python_tests/system_tests.py
@@ -54,9 +54,6 @@ class system_tests(unittest.TestCase):
                     }
                     '''
                 
-                tracepoints = process(file_content, language=language)
-                self.assertEqual(1 + TRACEBUFFER_INFO_COUNT, len(tracepoints))
-                self.assertEqual(tracepoints["formatted"][TRACEBUFFER_INFO_COUNT], "should be in tracebuffer")
+                stderr :str = process(file_content, language=language, run_musst_fail=True)
+                self.assertRegex(stderr, r'^\x1b\[1;31mclltk recoverable: could not open tracebuffer')
                 pass
-
-#endif 

--- a/tests/tracing.tests/api.tests/_open_tracebuffer.tests.cpp
+++ b/tests/tracing.tests/api.tests/_open_tracebuffer.tests.cpp
@@ -34,6 +34,9 @@ TEST_P(valid_paths, init_twice_valid)
 		{name.data(), 1024}, {nullptr, nullptr}, {nullptr, 0}};
 	_clltk_tracebuffer_init(&handler_1);
 	EXPECT_EQ(handler_0.runtime.tracebuffer, handler_1.runtime.tracebuffer);
+
+	_clltk_tracebuffer_deinit(&handler_0);
+	_clltk_tracebuffer_deinit(&handler_1);
 }
 
 INSTANTIATE_TEST_CASE_P(open_tracebuffer, valid_paths, ::testing::Values("asd", "s"));

--- a/tests/tracing.tests/api.tests/_tracebuffer_add_to_stack.tests.cpp
+++ b/tests/tracing.tests/api.tests/_tracebuffer_add_to_stack.tests.cpp
@@ -27,6 +27,8 @@ TEST_F(tracebuffer_add_to_stack, simple)
 	std::string str = "data set from simple";
 	const auto offset = _clltk_tracebuffer_add_to_stack(&handler, str.data(), (uint32_t)str.size());
 	EXPECT_GT(offset, 0);
+
+	_clltk_tracebuffer_deinit(&handler);
 }
 
 TEST_F(tracebuffer_add_to_stack, twice_same)
@@ -46,6 +48,8 @@ TEST_F(tracebuffer_add_to_stack, twice_same)
 	const auto offset1 =
 		_clltk_tracebuffer_add_to_stack(&handler, str.data(), (uint32_t)str.size());
 	EXPECT_EQ(offset0, offset1);
+
+	_clltk_tracebuffer_deinit(&handler);
 }
 
 TEST_F(tracebuffer_add_to_stack, twice_different)
@@ -67,6 +71,8 @@ TEST_F(tracebuffer_add_to_stack, twice_different)
 		_clltk_tracebuffer_add_to_stack(&handler, str1.data(), (uint32_t)str1.size());
 	EXPECT_GT(offset1, 0);
 	EXPECT_NE(offset0, offset1);
+
+	_clltk_tracebuffer_deinit(&handler);
 }
 
 TEST_F(tracebuffer_add_to_stack, bigger_than_one_page)
@@ -81,4 +87,6 @@ TEST_F(tracebuffer_add_to_stack, bigger_than_one_page)
 	const auto offset0 =
 		_clltk_tracebuffer_add_to_stack(&handler, data.data(), (uint32_t)data.size());
 	EXPECT_GT(offset0, 0);
+
+	_clltk_tracebuffer_deinit(&handler);
 }

--- a/tests/tracing.tests/api.tests/api.test.cpp
+++ b/tests/tracing.tests/api.tests/api.test.cpp
@@ -41,6 +41,9 @@ TEST_F(api, full_test)
 			_clltk_tracebuffer_add_to_stack(&tb, str.data(), (uint32_t)str.size());
 		}
 	}
+
+	for (auto &tb : tbs)
+		_clltk_tracebuffer_deinit(&tb);
 }
 
 TEST_F(api, delete_tracebuffer)

--- a/tracing_library/CMakeLists.txt
+++ b/tracing_library/CMakeLists.txt
@@ -139,11 +139,6 @@ target_compile_options(clltk_tracing_static
         ${clltk_private_compiler_flags}
 )
 
-# target_precompile_headers(clltk_tracing_static 
-#     INTERFACE
-#         ${CMAKE_CURRENT_SOURCE_DIR}/include/CommonLowLevelTracingKit/tracing.h
-# )
-
 add_library(clltk_tracing_shared SHARED
     ${CLLTK_TRACING_SOURCE}
 )
@@ -185,12 +180,6 @@ target_link_options(clltk_tracing_shared
         -Wl,--gc-sections
 )
 
-# target_precompile_headers(clltk_tracing_shared 
-#     INTERFACE
-#         ${CMAKE_CURRENT_SOURCE_DIR}/include/CommonLowLevelTracingKit/tracing.h
-# )
-
-
 # create alias target clltk_tracing based on set cache option
 string(TOUPPER "${CLLTK_TRACING_LIB_TYPE}" CLLTK_TRACING_LIB_TYPE)
 if(${CLLTK_TRACING_LIB_TYPE} STREQUAL "STATIC")
@@ -209,7 +198,6 @@ set(PULIC_HEADERS
     include/CommonLowLevelTracingKit/_user_tracing.h
     include/CommonLowLevelTracingKit/tracing.h
 )
-
 
 set_target_properties(clltk_tracing_static PROPERTIES 
     PUBLIC_HEADER "${PULIC_HEADERS}"

--- a/tracing_library/include/CommonLowLevelTracingKit/_internal.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/_internal.h
@@ -29,7 +29,7 @@ enum {
 
 typedef struct _clltk_tracebuffer_handler_t _clltk_tracebuffer_handler_t;
 struct _clltk_tracebuffer_handler_t {
-	struct {
+	const struct {
 		const char *const name;
 		const size_t size;
 	} definition;
@@ -42,11 +42,6 @@ struct _clltk_tracebuffer_handler_t {
 		_clltk_file_offset_t file_offset;
 	} runtime;
 };
-
-static inline bool _clltk_tracebuffer_open(_clltk_tracebuffer_handler_t *buffer)
-{
-	return buffer && buffer->runtime.tracebuffer && buffer->runtime.tracebuffer;
-}
 
 void _clltk_tracebuffer_init(_clltk_tracebuffer_handler_t *buffer)
 	__attribute__((used, visibility("default")));

--- a/tracing_library/include/CommonLowLevelTracingKit/_kernel_tracing.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/_kernel_tracing.h
@@ -34,13 +34,13 @@ typedef struct {
 #ifndef _CLLTK_INTERNAL
 
 void _clltk_init_tracing_for_this_module(const struct mod_kallsyms *const);
-__attribute__((constructor(102), used)) static void _clltk_constructor(void)
+__attribute__((constructor(101), used)) static void _clltk_constructor(void)
 {
 	_clltk_init_tracing_for_this_module(THIS_MODULE->kallsyms);
 }
 
 void _clltk_deinit_tracing_for_this_module(const struct mod_kallsyms *const);
-__attribute__((destructor(102), used)) static void _clltk_destructor(void)
+__attribute__((destructor(101), used)) static void _clltk_destructor(void)
 {
 	_clltk_deinit_tracing_for_this_module(THIS_MODULE->kallsyms);
 }

--- a/tracing_library/source/tracebuffer.h
+++ b/tracing_library/source/tracebuffer.h
@@ -47,4 +47,4 @@ struct _clltk_tracebuffer_t {
 };
 
 void add_to_ringbuffer(_clltk_tracebuffer_handler_t *_clltk_tracebuffer_handler_t,
-					   const void *const entry, size_t size);
+					   const void *const entry, size_t size) __attribute__((nonnull(1)));

--- a/tracing_library/source/tracepoint.c
+++ b/tracing_library/source/tracepoint.c
@@ -206,7 +206,9 @@ void clltk_dynamic_tracepoint_execution(const char *name, const char *file, cons
 
 	// add to ringbuffer
 	_clltk_tracebuffer_handler_t handler = {{name, 10 * 1024}, {NULL, NULL}, {NULL, 0}};
+	_clltk_tracebuffer_init(&handler);
 	add_to_ringbuffer(&handler, raw_entry_buffer, raw_entry_size);
+	_clltk_tracebuffer_deinit(&handler);
 
 	if (raw_buffer_is_heap_allocated) {
 		memory_heap_free(raw_entry_buffer);


### PR DESCRIPTION
fix race condition in tracing if a tracepoint needs to open tracebuffer dynamically during runtime.
Now only open tracebuffers at the start and close them at the end. 