### PR TITLE
fix: Add explicit dependency checks for optional components

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,10 @@
-1.2.63
+1.2.64
 
 # Change log
+## 1.2.64
+- feat: add explicit dependency checks for optional components
+- feat: disable automatic source RPM generation
+- fix: prevent cryptic build failures when dependencies are missing
 ## 1.2.63
 - fix: kernel Makefile now generates version header automatically
 ## 1.2.62

--- a/cmake/CreatePackage.cmake
+++ b/cmake/CreatePackage.cmake
@@ -48,6 +48,10 @@ set(CPACK_RPM_PACKAGE_RELEASE_DIST ON)
 set(CPACK_RPM_PACKAGE_LICENSE "BSD-2-Clause-Patent")
 set(CPACK_RPM_BUILD_SOURCE_DIRS_PREFIX "/clltk-debug")
 
+# Disable automatic source RPM generation
+# Source RPMs can still be built explicitly via the 'srpm' target
+set(CPACK_SOURCE_GENERATOR "")
+
 # Per-component RPM package names
 set(CPACK_RPM_TRACING_PACKAGE_NAME "clltk-tracing")
 set(CPACK_RPM_DECODER_LIBS_PACKAGE_NAME "clltk-decoder")

--- a/command_line_tool/interface/CMakeLists.txt
+++ b/command_line_tool/interface/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Copyright (c) 2024, International Business Machines
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
-
+# Check for required dependencies
+find_package(RapidJSON QUIET)
+if(NOT RapidJSON_FOUND)
+    message(FATAL_ERROR "command_line_tool requires rapidjson-devel package. Install it or disable with -DCLLTK_COMMAND_LINE_TOOL=OFF")
+endif()
 
 find_package(RapidJSON REQUIRED)
 find_package(CLI11 REQUIRED)

--- a/decoder_tool/cpp/CMakeLists.txt
+++ b/decoder_tool/cpp/CMakeLists.txt
@@ -1,5 +1,11 @@
 
 
+# Check for required Boost dependency
+find_package(Boost QUIET CONFIG)
+if(NOT Boost_FOUND)
+    message(FATAL_ERROR "cpp decoder requires boost-devel package. Install it or disable with -DCLLTK_CPP_DECODER=OFF")
+endif()
+
 find_package(Boost REQUIRED CONFIG)
 
 set(TARGET_SOURCES

--- a/snapshot_library/CMakeLists.txt
+++ b/snapshot_library/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Copyright (c) 2024, International Business Machines
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
+# Check for required libarchive dependency
+find_library(ARCHIVE_LIBRARY NAMES archive)
+if(NOT ARCHIVE_LIBRARY)
+    message(FATAL_ERROR "snapshot_library requires libarchive-devel package. Install it or disable with -DCLLTK_SNAPSHOT=OFF")
+endif()
+
 add_library(clltk_snapshot_static STATIC
     source/file.cpp
     source/snapshot.cpp


### PR DESCRIPTION
## Summary

Add early CMake dependency validation for optional components to provide clear error messages when required packages are missing.

## Changes

- **snapshot_library**: Check for libarchive-devel before building
- **command_line_tool**: Check for rapidjson-devel before building  
- **cpp decoder**: Check for boost-devel before building

Each check provides an actionable error message with the CMake flag to disable the component if the dependency cannot be installed (e.g., `-DCLLTK_SNAPSHOT=OFF`).

## Benefits

- Prevents cryptic build failures later in the build process
- Provides clear, actionable error messages to users
- Aligns with the Gradle build system's component enable/disable flags
- Improves developer experience when building in environments with missing dependencies

## Testing

The changes can be tested by:
1. Building with all dependencies present (should work as before)
2. Building with a missing dependency (should fail early with clear message)
3. Building with component disabled via CMake flag (should skip the component)

Relates to the CommonLowLevelTracingKit_build Gradle integration work.