### PR TITLE
fix: GCC 15 section type conflict; faster, earlier startup registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,46 @@ jobs:
         run: ./scripts/container.sh ./scripts/ci-cd/step_memcheck.sh
 
   # ============================================
+  # Build without LTO (consumer-like compile)
+  # The default presets build everything with IPO/LTO, which defers ELF
+  # section assignment and hides section conflicts (e.g. GCC 15 rejecting
+  # COMDAT vs plain sections of the same name) that break consumers who
+  # compile against the installed headers without LTO.
+  # ============================================
+  build-nolto:
+    runs-on: ubuntu-latest
+    needs: [changes, checks]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name == 'push' ||
+       needs.changes.outputs.code == 'true' ||
+       needs.changes.outputs.tests == 'true' ||
+       needs.changes.outputs.ci == 'true')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup ccache
+        run: mkdir -p ~/.ccache
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-nolto-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-nolto-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}-
+            ccache-${{ runner.os }}-nolto-
+
+      - name: Load CI-Container
+        uses: ./.github/actions/load-container
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (no LTO)
+        run: ./scripts/container.sh ./scripts/ci-cd/step_build.sh --preset unittests-nolto
+
+  # ============================================
   # Packaging (only for code/ci changes, or push to main)
   # ============================================
   package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,34 @@ jobs:
         run: ./scripts/container.sh ./scripts/ci-cd/step_build.sh --preset unittests-nolto
 
   # ============================================
+  # Kernel modules (compile + modpost link check)
+  # The kernel module shares sources with the userspace library but is
+  # built by Kbuild against real kernel headers - userspace builds cannot
+  # catch kernel-only failures (missing libgcc helpers, kernel API use).
+  # Runtime testing stays in scripts/ci-cd/test_kernelspace.sh (QEMU).
+  # ============================================
+  build-kernel-module:
+    runs-on: ubuntu-latest
+    needs: [changes, checks]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name == 'push' ||
+       needs.changes.outputs.code == 'true' ||
+       needs.changes.outputs.tests == 'true' ||
+       needs.changes.outputs.ci == 'true')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Load CI-Container
+        uses: ./.github/actions/load-container
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build kernel modules
+        run: ./scripts/container.sh ./scripts/ci-cd/step_build_kernel_module.sh
+
+  # ============================================
   # Packaging (only for code/ci changes, or push to main)
   # ============================================
   package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,9 @@ run-name: CI by ${{ github.actor }}
 on:
   push:
     branches: ['main']
+  # no branch filter: stacked PRs target feature branches and would
+  # otherwise get no CI at all
   pull_request:
-    branches: ['main']
 
 env:
   CI: true

--- a/.github/workflows/container-refresh.yml
+++ b/.github/workflows/container-refresh.yml
@@ -1,0 +1,65 @@
+name: Container Refresh
+run-name: Weekly container refresh
+
+# The CI container is cached in ghcr.io keyed only by the Dockerfile hash,
+# but its toolchain comes from "dnf update" at image build time. Without a
+# periodic uncached rebuild, compiler updates (like the GCC 15.2 section
+# type conflict) only reach CI when the Dockerfile happens to change - and
+# break consumers first. This workflow rebuilds the image from scratch every
+# week, validates it with a full build and test run, and only then replaces
+# the cached image in the registry.
+
+on:
+  schedule:
+    - cron: "0 3 * * 1" # Monday 03:00 UTC
+  workflow_dispatch:
+
+env:
+  CI: true
+  CONTAINER_TARGET: ci
+  CONTAINER_CMD: docker
+  CONTAINER_NON_INTERACTIVE: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Calculate container tag
+        id: tag
+        run: |
+          MD5_SUM=$(md5sum ./scripts/container.Dockerfile | cut -d' ' -f1)
+          echo "local_tag=clltk_ci-ci-$MD5_SUM" >> $GITHUB_OUTPUT
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "registry_image=ghcr.io/${REPO_LOWER}/ci:${MD5_SUM}" >> $GITHUB_OUTPUT
+
+      - name: Build container without cache
+        run: |
+          docker build --no-cache \
+            --file ./scripts/container.Dockerfile \
+            --target ci \
+            --tag "${{ steps.tag.outputs.local_tag }}" .
+
+      - name: Validate refreshed container (build)
+        run: ./scripts/container.sh ./scripts/ci-cd/step_build.sh
+
+      - name: Validate refreshed container (test)
+        run: ./scripts/container.sh ./scripts/ci-cd/step_test.sh
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push refreshed container
+        run: |
+          docker tag "${{ steps.tag.outputs.local_tag }}" "${{ steps.tag.outputs.registry_image }}"
+          docker push "${{ steps.tag.outputs.registry_image }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ docs/               AsciiDoc documentation, file format spec, diagrams.
 - `CLLTK_DYN_TRACEPOINT` takes a string buffer name (not an identifier) and binds at runtime. Slower than static tracepoints.
 
 ### ELF Sections
-- Meta entries are ordinary `static const` objects; a pointer to each is emitted into the custom ELF section `_clltk_<BUFFER_NAME>_metaptr` via an inline-asm `.pushsection` data directive (NOT via `__attribute__((section(...)))` -- the attribute would join the enclosing function's COMDAT group inside inline functions and templates, and GCC >= 15.2 rejects mixing grouped and ungrouped sections of the same name). Buffer names MUST be valid C identifiers.
+- Meta entries are ordinary `static const` objects; each call site emits a pointer pair `{meta, file-offset cache}` into the custom ELF section `_clltk_<BUFFER_NAME>_metaptr` via an inline-asm `.pushsection` data directive. The constructor registers every meta at startup and writes the resolved file offset into the cache, so the first tracepoint execution needs no lookup (NOT via `__attribute__((section(...)))` -- the attribute would join the enclosing function's COMDAT group inside inline functions and templates, and GCC >= 15.2 rejects mixing grouped and ungrouped sections of the same name). Buffer names MUST be valid C identifiers.
 - Constructor/destructor priority is 101 (very early). User code with priority <= 101 cannot use tracing.
 - `_CLLTK_INTERNAL` define gates macro expansion. The library itself compiles with `-D_CLLTK_INTERNAL`; consumer code must NOT define it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ docs/               AsciiDoc documentation, file format spec, diagrams.
 
 ### ELF Sections
 - Meta entries are ordinary `static const` objects; each call site emits a pointer pair `{meta, file-offset cache}` into the custom ELF section `_clltk_<BUFFER_NAME>_metaptr` via an inline-asm `.pushsection` data directive. The constructor registers every meta at startup and writes the resolved file offset into the cache, so the first tracepoint execution needs no lookup (NOT via `__attribute__((section(...)))` -- the attribute would join the enclosing function's COMDAT group inside inline functions and templates, and GCC >= 15.2 rejects mixing grouped and ungrouped sections of the same name). Buffer names MUST be valid C identifiers.
-- Constructor/destructor priority is 101 (very early). User code with priority <= 101 cannot use tracing.
+- Constructor/destructor priority is 101 (very early). User code with priority < 101 cannot use tracing; at priority exactly 101 the order against clltk's own constructor/destructor is emission-order dependent (LTO flips it), so tracing there is undefined -- it may or may not be recorded.
 - `_CLLTK_INTERNAL` define gates macro expansion. The library itself compiles with `-D_CLLTK_INTERNAL`; consumer code must NOT define it.
 
 ### API Typo -- Do NOT Fix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ docs/               AsciiDoc documentation, file format spec, diagrams.
 - `CLLTK_DYN_TRACEPOINT` takes a string buffer name (not an identifier) and binds at runtime. Slower than static tracepoints.
 
 ### ELF Sections
-- Metadata is placed in custom ELF sections (`_clltk_<BUFFER_NAME>_meta`) via `__attribute__((section(...)))`. Buffer names MUST be valid C identifiers.
+- Meta entries are ordinary `static const` objects; a pointer to each is emitted into the custom ELF section `_clltk_<BUFFER_NAME>_metaptr` via an inline-asm `.pushsection` data directive (NOT via `__attribute__((section(...)))` -- the attribute would join the enclosing function's COMDAT group inside inline functions and templates, and GCC >= 15.2 rejects mixing grouped and ungrouped sections of the same name). Buffer names MUST be valid C identifiers.
 - Constructor/destructor priority is 101 (very early). User code with priority <= 101 cannot use tracing.
 - `_CLLTK_INTERNAL` define gates macro expansion. The library itself compiles with `-D_CLLTK_INTERNAL`; consumer code must NOT define it.
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,6 +28,14 @@
             }
         },
         {
+            "name": "unittests-nolto",
+            "inherits": "unittests",
+            "description": "Consumer-like build without LTO. IPO/LTO defers section assignment and hides ELF section conflicts that break non-LTO consumers of the tracing headers.",
+            "cacheVariables": {
+                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF"
+            }
+        },
+        {
             "name": "rpm",
             "inherits": "default",
             "cacheVariables": {
@@ -61,6 +69,13 @@
         {
             "name": "unittests",
             "configurePreset": "unittests",
+            "targets": [
+                "all"
+            ]
+        },
+        {
+            "name": "unittests-nolto",
+            "configurePreset": "unittests-nolto",
             "targets": [
                 "all"
             ]

--- a/VERSION.md
+++ b/VERSION.md
@@ -4,8 +4,11 @@
 ## 1.3.0
 - fix: tracepoints in inline functions, templates, and class members no longer fail with
   "causes a section type conflict" on GCC >= 15.2. Meta entries are now ordinary statics;
-  discovery works through pointers emitted into `_clltk_<BUFFER>_metaptr` sections via
-  assembler data directives (COMDAT-safe, validated for x86_64/aarch64/s390x with -fPIC).
+  discovery works through {meta, offset-cache} pointer pairs emitted into
+  `_clltk_<BUFFER>_metaptr` sections via assembler data directives (COMDAT-safe, validated
+  for x86_64/aarch64/s390x with -fPIC).
+- perf: startup registration writes each call site's file offset into its cache, so the
+  first execution of a tracepoint needs no lookup.
 - feat: decoder/CLI read both the new `_metaptr` pointer sections and legacy inline `_meta`
   sections from ELF binaries.
 - BREAKING (link-time): objects compiled with older headers cannot be mixed with objects

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,16 @@
-1.2.64
+1.3.0
 
 # Change log
+## 1.3.0
+- fix: tracepoints in inline functions, templates, and class members no longer fail with
+  "causes a section type conflict" on GCC >= 15.2. Meta entries are now ordinary statics;
+  discovery works through pointers emitted into `_clltk_<BUFFER>_metaptr` sections via
+  assembler data directives (COMDAT-safe, validated for x86_64/aarch64/s390x with -fPIC).
+- feat: decoder/CLI read both the new `_metaptr` pointer sections and legacy inline `_meta`
+  sections from ELF binaries.
+- BREAKING (link-time): objects compiled with older headers cannot be mixed with objects
+  compiled with these headers in one binary; rebuild all translation units.
+- ci: add non-LTO build leg (`unittests-nolto` preset); LTO had masked the section conflict.
 ## 1.2.64
 - feat: add explicit dependency checks for optional components
 - feat: disable automatic source RPM generation

--- a/VERSION.md
+++ b/VERSION.md
@@ -14,6 +14,14 @@
 - BREAKING (link-time): objects compiled with older headers cannot be mixed with objects
   compiled with these headers in one binary; rebuild all translation units.
 - ci: add non-LTO build leg (`unittests-nolto` preset); LTO had masked the section conflict.
+- feat: `clltk meta` reads tracepoint metadata from relocatable objects (.o) via relocation
+  records.
+- fix: handlers detach from the tracebuffer on every deinit; tracepoints firing after
+  teardown no longer touch freed memory.
+- perf: batched startup registration with a single stack scan and a single file write.
+- ci: fix container.sh quoting (argument array instead of eval); weekly uncached container
+  rebuild; RPM test cache invalidation on version change.
+- fix: python decoder accepts newer minor file versions (gate on major only).
 ## 1.2.64
 - feat: add explicit dependency checks for optional components
 - feat: disable automatic source RPM generation

--- a/decoder_tool/cpp/source/low_level/elf_reader.cpp
+++ b/decoder_tool/cpp/source/low_level/elf_reader.cpp
@@ -66,6 +66,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 				info.name = getSectionName(data, shstrtab_hdr.sh_offset, shdr.sh_name);
 				info.offset = shdr.sh_offset;
 				info.size = shdr.sh_size;
+				info.addr = shdr.sh_addr;
 				info.type = shdr.sh_type;
 
 				sections.push_back(std::move(info));
@@ -97,6 +98,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 				info.name = getSectionName(data, shstrtab_hdr.sh_offset, shdr.sh_name);
 				info.offset = shdr.sh_offset;
 				info.size = shdr.sh_size;
+				info.addr = shdr.sh_addr;
 				info.type = shdr.sh_type;
 
 				sections.push_back(std::move(info));
@@ -105,17 +107,83 @@ namespace CommonLowLevelTracingKit::decoder::source {
 			return sections;
 		}
 
-		bool isClltkMetaSection(const std::string &name) {
-			const size_t prefix_len = std::strlen(ElfReader::SECTION_PREFIX);
-			const size_t suffix_len = std::strlen(ElfReader::SECTION_SUFFIX);
+		bool hasPrefixAndSuffix(const std::string &name, const char *prefix, const char *suffix) {
+			const size_t prefix_len = std::strlen(prefix);
+			const size_t suffix_len = std::strlen(suffix);
 
 			if (name.size() < prefix_len + suffix_len + 1) { return false; }
-			if (name.compare(0, prefix_len, ElfReader::SECTION_PREFIX) != 0) { return false; }
-			if (name.compare(name.size() - suffix_len, suffix_len, ElfReader::SECTION_SUFFIX) !=
-				0) {
-				return false;
-			}
+			if (name.compare(0, prefix_len, prefix) != 0) { return false; }
+			if (name.compare(name.size() - suffix_len, suffix_len, suffix) != 0) { return false; }
 			return true;
+		}
+
+		bool isClltkMetaPtrSection(const std::string &name) {
+			return hasPrefixAndSuffix(name, ElfReader::SECTION_PREFIX,
+									  ElfReader::SECTION_PTR_SUFFIX);
+		}
+
+		bool isClltkMetaSection(const std::string &name) {
+			return !isClltkMetaPtrSection(name) &&
+				   hasPrefixAndSuffix(name, ElfReader::SECTION_PREFIX, ElfReader::SECTION_SUFFIX);
+		}
+
+		bool isAnyClltkMetaSection(const std::string &name) {
+			return isClltkMetaSection(name) || isClltkMetaPtrSection(name);
+		}
+
+		// Parse a pointer-layout discovery section: every entry is a virtual
+		// address of a meta entry located in some allocated section (e.g.
+		// .rodata). Resolve each address through the section table to a file
+		// offset and parse the self-describing meta entry found there.
+		// Duplicate addresses (e.g. from inlined call sites) are skipped.
+		MetaEntryInfoCollection parsePointerSection(const std::vector<uint8_t> &data,
+													const std::vector<ElfSectionInfo> &sections,
+													const ElfSectionInfo &ptr_section,
+													size_t pointer_size) {
+			MetaEntryInfoCollection entries;
+
+			std::vector<uint64_t> seen;
+			const size_t count = ptr_section.size / pointer_size;
+			for (size_t i = 0; i < count; ++i) {
+				const size_t ptr_offset = ptr_section.offset + i * pointer_size;
+				if (ptr_offset + pointer_size > data.size()) { break; }
+
+				uint64_t address = 0;
+				std::memcpy(&address, data.data() + ptr_offset, pointer_size);
+				if (address == 0) { continue; } // unresolved (relocatable object)
+				if (std::find(seen.begin(), seen.end(), address) != seen.end()) { continue; }
+				seen.push_back(address);
+
+				for (const auto &section : sections) {
+					if (section.addr == 0 || section.size == 0) { continue; }
+					if (address < section.addr || address >= section.addr + section.size) {
+						continue;
+					}
+					const uint64_t entry_offset = section.offset + (address - section.addr);
+					if (entry_offset + MetaParser::MIN_ENTRY_SIZE > data.size()) { break; }
+
+					uint32_t entry_size = 0;
+					std::memcpy(&entry_size, data.data() + entry_offset + MetaParser::OFFSET_SIZE,
+								sizeof(entry_size));
+					if (entry_size < MetaParser::MIN_ENTRY_SIZE ||
+						entry_offset + entry_size > data.size()) {
+						break;
+					}
+
+					const std::span<const uint8_t> entry_data(data.data() + entry_offset,
+															  entry_size);
+					auto parsed = MetaParser::parse(entry_data, entry_offset);
+					entries.insert(entries.end(), std::make_move_iterator(parsed.begin()),
+								   std::make_move_iterator(parsed.end()));
+					break;
+				}
+			}
+
+			return entries;
+		}
+
+		size_t pointerSize(const std::vector<uint8_t> &data) {
+			return is64Bit(data) ? sizeof(uint64_t) : sizeof(uint32_t);
 		}
 
 	} // namespace
@@ -134,7 +202,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 	bool ElfReader::hasClltkSections(const std::filesystem::path &path) {
 		const auto sections = getSections(path);
 		return std::any_of(sections.begin(), sections.end(),
-						   [](const auto &s) { return isClltkMetaSection(s.name); });
+						   [](const auto &s) { return isAnyClltkMetaSection(s.name); });
 	}
 
 	std::vector<std::string> ElfReader::getClltkSectionNames(const std::filesystem::path &path) {
@@ -142,7 +210,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 		const auto sections = getSections(path);
 
 		for (const auto &section : sections) {
-			if (isClltkMetaSection(section.name)) { names.push_back(section.name); }
+			if (isAnyClltkMetaSection(section.name)) { names.push_back(section.name); }
 		}
 
 		return names;
@@ -158,12 +226,17 @@ namespace CommonLowLevelTracingKit::decoder::source {
 	}
 
 	std::string ElfReader::extractTracebufferName(const std::string &section_name) {
-		if (!isClltkMetaSection(section_name)) { return ""; }
-
 		const size_t prefix_len = std::strlen(SECTION_PREFIX);
-		const size_t suffix_len = std::strlen(SECTION_SUFFIX);
 
-		return section_name.substr(prefix_len, section_name.size() - prefix_len - suffix_len);
+		if (isClltkMetaPtrSection(section_name)) {
+			const size_t suffix_len = std::strlen(SECTION_PTR_SUFFIX);
+			return section_name.substr(prefix_len, section_name.size() - prefix_len - suffix_len);
+		}
+		if (isClltkMetaSection(section_name)) {
+			const size_t suffix_len = std::strlen(SECTION_SUFFIX);
+			return section_name.substr(prefix_len, section_name.size() - prefix_len - suffix_len);
+		}
+		return "";
 	}
 
 	MetaEntryInfoCollection ElfReader::readMetaFromSection(const std::filesystem::path &path,
@@ -175,6 +248,9 @@ namespace CommonLowLevelTracingKit::decoder::source {
 			if (section.name != section_name) { continue; }
 			if (section.offset + section.size > data.size()) { continue; }
 
+			if (isClltkMetaPtrSection(section.name)) {
+				return parsePointerSection(data, sections, section, pointerSize(data));
+			}
 			const std::span<const uint8_t> section_data(data.data() + section.offset, section.size);
 			return MetaParser::parse(section_data, section.offset);
 		}
@@ -192,7 +268,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 		const auto sections = is64Bit(data) ? parseSections64(data) : parseSections32(data);
 
 		for (const auto &section : sections) {
-			if (!isClltkMetaSection(section.name)) { continue; }
+			if (!isAnyClltkMetaSection(section.name)) { continue; }
 
 			MetaSourceInfo info;
 			info.name = extractTracebufferName(section.name);
@@ -206,8 +282,16 @@ namespace CommonLowLevelTracingKit::decoder::source {
 				continue;
 			}
 
-			const std::span<const uint8_t> section_data(data.data() + section.offset, section.size);
-			info.entries = MetaParser::parse(section_data, section.offset);
+			if (isClltkMetaPtrSection(section.name)) {
+				info.entries = parsePointerSection(data, sections, section, pointerSize(data));
+				if (info.entries.empty() && section.size >= pointerSize(data)) {
+					info.error = "no resolvable meta pointers (relocatable object?)";
+				}
+			} else {
+				const std::span<const uint8_t> section_data(data.data() + section.offset,
+															section.size);
+				info.entries = MetaParser::parse(section_data, section.offset);
+			}
 
 			results.push_back(std::move(info));
 		}

--- a/decoder_tool/cpp/source/low_level/elf_reader.cpp
+++ b/decoder_tool/cpp/source/low_level/elf_reader.cpp
@@ -131,11 +131,13 @@ namespace CommonLowLevelTracingKit::decoder::source {
 			return isClltkMetaSection(name) || isClltkMetaPtrSection(name);
 		}
 
-		// Parse a pointer-layout discovery section: every entry is a virtual
-		// address of a meta entry located in some allocated section (e.g.
-		// .rodata). Resolve each address through the section table to a file
-		// offset and parse the self-describing meta entry found there.
-		// Duplicate addresses (e.g. from inlined call sites) are skipped.
+		// Parse a pointer-layout discovery section: every entry is a pointer
+		// pair {meta address, offset-cache address}. The meta address points
+		// into some allocated section (e.g. .rodata); the offset cache is
+		// runtime-only state and ignored here. Resolve each meta address
+		// through the section table to a file offset and parse the
+		// self-describing meta entry found there. Duplicate addresses (e.g.
+		// from inlined call sites) are skipped.
 		MetaEntryInfoCollection parsePointerSection(const std::vector<uint8_t> &data,
 													const std::vector<ElfSectionInfo> &sections,
 													const ElfSectionInfo &ptr_section,
@@ -143,9 +145,10 @@ namespace CommonLowLevelTracingKit::decoder::source {
 			MetaEntryInfoCollection entries;
 
 			std::vector<uint64_t> seen;
-			const size_t count = ptr_section.size / pointer_size;
+			const size_t entry_stride = 2 * pointer_size;
+			const size_t count = ptr_section.size / entry_stride;
 			for (size_t i = 0; i < count; ++i) {
-				const size_t ptr_offset = ptr_section.offset + i * pointer_size;
+				const size_t ptr_offset = ptr_section.offset + i * entry_stride;
 				if (ptr_offset + pointer_size > data.size()) { break; }
 
 				uint64_t address = 0;

--- a/decoder_tool/cpp/source/low_level/elf_reader.cpp
+++ b/decoder_tool/cpp/source/low_level/elf_reader.cpp
@@ -131,6 +131,89 @@ namespace CommonLowLevelTracingKit::decoder::source {
 			return isClltkMetaSection(name) || isClltkMetaPtrSection(name);
 		}
 
+		// parse one self-describing meta entry (magic + size prefix) located
+		// at a file offset and append the result
+		void appendMetaEntryAt(const std::vector<uint8_t> &data, uint64_t entry_offset,
+							   MetaEntryInfoCollection &entries) {
+			if (entry_offset + MetaParser::MIN_ENTRY_SIZE > data.size()) { return; }
+
+			uint32_t entry_size = 0;
+			std::memcpy(&entry_size, data.data() + entry_offset + MetaParser::OFFSET_SIZE,
+						sizeof(entry_size));
+			if (entry_size < MetaParser::MIN_ENTRY_SIZE ||
+				entry_offset + entry_size > data.size()) {
+				return;
+			}
+
+			const std::span<const uint8_t> entry_data(data.data() + entry_offset, entry_size);
+			auto parsed = MetaParser::parse(entry_data, entry_offset);
+			entries.insert(entries.end(), std::make_move_iterator(parsed.begin()),
+						   std::make_move_iterator(parsed.end()));
+		}
+
+		bool isRelocatable(const std::vector<uint8_t> &data) {
+			if (data.size() < sizeof(Elf64_Ehdr)) { return false; }
+			// e_type sits at the same offset for ELFCLASS32 and ELFCLASS64
+			uint16_t e_type = 0;
+			std::memcpy(&e_type, data.data() + offsetof(Elf64_Ehdr, e_type), sizeof(e_type));
+			return e_type == ET_REL;
+		}
+
+		// In relocatable objects (.o) the pointer slots are zero; the meta
+		// locations live in the .rela<section> relocation records instead:
+		// each relocation names a symbol (whose section and value give the
+		// target location) plus an addend. Only entries at even slots are
+		// meta pointers; odd slots point at the runtime offset caches and
+		// are skipped. 64-bit RELA only, which covers all supported targets.
+		MetaEntryInfoCollection
+		parseRelocatedPointerSection(const std::vector<uint8_t> &data,
+									 const std::vector<ElfSectionInfo> &sections,
+									 const ElfSectionInfo &ptr_section, size_t pointer_size) {
+			MetaEntryInfoCollection entries;
+			if (!is64Bit(data)) { return entries; }
+
+			const ElfSectionInfo *symtab = nullptr;
+			const ElfSectionInfo *rela = nullptr;
+			const std::string rela_name = ".rela" + ptr_section.name;
+			for (const auto &section : sections) {
+				if (section.type == SHT_SYMTAB) { symtab = &section; }
+				if (section.type == SHT_RELA && section.name == rela_name) { rela = &section; }
+			}
+			if (symtab == nullptr || rela == nullptr) { return entries; }
+			if (rela->offset + rela->size > data.size()) { return entries; }
+
+			std::vector<uint64_t> seen;
+			const size_t entry_stride = 2 * pointer_size;
+			const size_t count = rela->size / sizeof(Elf64_Rela);
+			for (size_t i = 0; i < count; ++i) {
+				Elf64_Rela relocation = {};
+				std::memcpy(&relocation, data.data() + rela->offset + i * sizeof(relocation),
+							sizeof(relocation));
+				if (relocation.r_offset % entry_stride != 0) { continue; } // offset cache slot
+
+				const uint64_t sym_index = ELF64_R_SYM(relocation.r_info);
+				const uint64_t sym_offset = symtab->offset + sym_index * sizeof(Elf64_Sym);
+				if (sym_offset + sizeof(Elf64_Sym) > data.size() ||
+					(sym_index + 1) * sizeof(Elf64_Sym) > symtab->size) {
+					continue;
+				}
+				Elf64_Sym symbol = {};
+				std::memcpy(&symbol, data.data() + sym_offset, sizeof(symbol));
+				if (symbol.st_shndx == SHN_UNDEF || symbol.st_shndx >= sections.size()) {
+					continue;
+				}
+
+				const auto &target = sections[symbol.st_shndx];
+				const uint64_t entry_offset =
+					target.offset + symbol.st_value + (uint64_t)relocation.r_addend;
+				if (std::find(seen.begin(), seen.end(), entry_offset) != seen.end()) { continue; }
+				seen.push_back(entry_offset);
+				appendMetaEntryAt(data, entry_offset, entries);
+			}
+
+			return entries;
+		}
+
 		// Parse a pointer-layout discovery section: every entry is a pointer
 		// pair {meta address, offset-cache address}. The meta address points
 		// into some allocated section (e.g. .rodata); the offset cache is
@@ -153,7 +236,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 
 				uint64_t address = 0;
 				std::memcpy(&address, data.data() + ptr_offset, pointer_size);
-				if (address == 0) { continue; } // unresolved (relocatable object)
+				if (address == 0) { continue; }
 				if (std::find(seen.begin(), seen.end(), address) != seen.end()) { continue; }
 				seen.push_back(address);
 
@@ -162,27 +245,22 @@ namespace CommonLowLevelTracingKit::decoder::source {
 					if (address < section.addr || address >= section.addr + section.size) {
 						continue;
 					}
-					const uint64_t entry_offset = section.offset + (address - section.addr);
-					if (entry_offset + MetaParser::MIN_ENTRY_SIZE > data.size()) { break; }
-
-					uint32_t entry_size = 0;
-					std::memcpy(&entry_size, data.data() + entry_offset + MetaParser::OFFSET_SIZE,
-								sizeof(entry_size));
-					if (entry_size < MetaParser::MIN_ENTRY_SIZE ||
-						entry_offset + entry_size > data.size()) {
-						break;
-					}
-
-					const std::span<const uint8_t> entry_data(data.data() + entry_offset,
-															  entry_size);
-					auto parsed = MetaParser::parse(entry_data, entry_offset);
-					entries.insert(entries.end(), std::make_move_iterator(parsed.begin()),
-								   std::make_move_iterator(parsed.end()));
+					appendMetaEntryAt(data, section.offset + (address - section.addr), entries);
 					break;
 				}
 			}
 
 			return entries;
+		}
+
+		MetaEntryInfoCollection parseAnyPointerSection(const std::vector<uint8_t> &data,
+													   const std::vector<ElfSectionInfo> &sections,
+													   const ElfSectionInfo &ptr_section,
+													   size_t pointer_size) {
+			if (isRelocatable(data)) {
+				return parseRelocatedPointerSection(data, sections, ptr_section, pointer_size);
+			}
+			return parsePointerSection(data, sections, ptr_section, pointer_size);
 		}
 
 		size_t pointerSize(const std::vector<uint8_t> &data) {
@@ -252,7 +330,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 			if (section.offset + section.size > data.size()) { continue; }
 
 			if (isClltkMetaPtrSection(section.name)) {
-				return parsePointerSection(data, sections, section, pointerSize(data));
+				return parseAnyPointerSection(data, sections, section, pointerSize(data));
 			}
 			const std::span<const uint8_t> section_data(data.data() + section.offset, section.size);
 			return MetaParser::parse(section_data, section.offset);
@@ -286,9 +364,9 @@ namespace CommonLowLevelTracingKit::decoder::source {
 			}
 
 			if (isClltkMetaPtrSection(section.name)) {
-				info.entries = parsePointerSection(data, sections, section, pointerSize(data));
+				info.entries = parseAnyPointerSection(data, sections, section, pointerSize(data));
 				if (info.entries.empty() && section.size >= pointerSize(data)) {
-					info.error = "no resolvable meta pointers (relocatable object?)";
+					info.error = "no resolvable meta pointers";
 				}
 			} else {
 				const std::span<const uint8_t> section_data(data.data() + section.offset,

--- a/decoder_tool/cpp/source/low_level/elf_reader.hpp
+++ b/decoder_tool/cpp/source/low_level/elf_reader.hpp
@@ -17,6 +17,7 @@ namespace CommonLowLevelTracingKit::decoder::source {
 		std::string name;
 		uint64_t offset;
 		uint64_t size;
+		uint64_t addr;
 		uint32_t type;
 	};
 
@@ -32,7 +33,11 @@ namespace CommonLowLevelTracingKit::decoder::source {
 		static std::string extractTracebufferName(const std::string &section_name);
 
 		static constexpr const char *SECTION_PREFIX = "_clltk_";
+		/// legacy layout: meta entries stored inline in the section
 		static constexpr const char *SECTION_SUFFIX = "_meta";
+		/// current layout: the section stores pointers to meta entries that
+		/// live in regular data sections (see _CLLTK_EMIT_META_PTR)
+		static constexpr const char *SECTION_PTR_SUFFIX = "_metaptr";
 
 	  private:
 		ElfReader() = delete;

--- a/decoder_tool/python/clltk_decoder.py
+++ b/decoder_tool/python/clltk_decoder.py
@@ -635,10 +635,11 @@ class Tracebuffer:
         version_major = 0xFF & (file_version // 0x10000)
         version_minor = 0xFF & (file_version // 0x100)
         version_patch = 0xFF & (file_version // 0x1)
+        # the trace file format is backward compatible within one major
+        # version: only gate on the major. Layout details that changed with a
+        # minor version are selected in get_const() with open-ended ranges,
+        # so newer minors decode fine and must not be rejected here.
         assert version_major == 1, f"invalid major version {version_major}"
-        # file format is unchanged since 1.2; 1.3 changed only the in-binary
-        # tracepoint discovery (ELF sections), not the trace file layout
-        assert version_minor <= 3, f"invalid minor version {version_minor}"
         self.version = f"{version_major}.{version_minor}.{version_patch}"
         
         global current_version

--- a/decoder_tool/python/clltk_decoder.py
+++ b/decoder_tool/python/clltk_decoder.py
@@ -636,7 +636,9 @@ class Tracebuffer:
         version_minor = 0xFF & (file_version // 0x100)
         version_patch = 0xFF & (file_version // 0x1)
         assert version_major == 1, f"invalid major version {version_major}"
-        assert version_minor <= 2, f"invalid minor version {version_minor}"
+        # file format is unchanged since 1.2; 1.3 changed only the in-binary
+        # tracepoint discovery (ELF sections), not the trace file layout
+        assert version_minor <= 3, f"invalid minor version {version_minor}"
         self.version = f"{version_major}.{version_minor}.{version_patch}"
         
         global current_version

--- a/docs/technical_documentation.asciidoc
+++ b/docs/technical_documentation.asciidoc
@@ -122,41 +122,41 @@ printf_like_function(receiver, "%d", (long)1); // gcc warning [-Wformat]
 ---
 
 === Gathering meta data at compile-time
-To get all meta data for one tracebuffer, all relevant information are stored in to a custom elf-section. This is possible due to a  
-link:https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Function-Attributes.html#:~:text=section%20(%22section%2Dname%22)[gcc section attribute].
-By defining all meta data strings and data structures as `static const` and applying the section attribute, gcc will gathering all meta data into the same section. 
+Each tracepoint's meta data is created as an ordinary `static const` struct at the call site.
+To make all tracepoints of one tracebuffer discoverable at startup, a pointer to each meta
+struct is collected in a custom elf-section named `_clltk_<BUFFER>_metaptr`.
+
+The pointer is emitted with an inline-assembly data directive instead of the
+link:https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html[gcc section attribute].
+The section attribute cannot be used here: inside inline functions and templates the compiler
+places function-local statics into the enclosing function's COMDAT group, and GCC (>= 15.2)
+rejects mixing COMDAT-grouped and ungrouped sections of the same name in one translation unit
+("causes a section type conflict"). Data emitted through assembler directives never joins a
+COMDAT group, so tracepoints work in any context: plain functions, inline functions, templates,
+C and C++.
 
 [source,C,linenums]
 ----
+// at every tracepoint call site (simplified):
+static const struct { ... } _meta __attribute__((used)) = { ... };
 
-// in first_file.cpp
-{
-    static const char filename[] __attribute__((used, section("my_section"))) = {__FILE__};
-    static const char format[] __attribute__((used, section("my_section"))) = {"first format string %s"};
-}
-
-// second_file.cpp
-{
-    static const char filename[] __attribute__((used, section("my_section"))) =  {__FILE__};
-    static const char format[] __attribute__((used, section("my_section"))) =  {"second format string %d"};
-}
-
-/* elf section "my_section" 
-.filename_0 "first_file.cpp\0"
-.format_0 "first format string %s\0"
-.filename_1 "second_file.cpp\0"
-.format_1 "second format string %s\0"
-*/
+__asm__(".pushsection _clltk_MYBUFFER_metaptr,\"a\"\n\t"
+        ".balign 8\n\t"
+        ".dc.a %c0\n\t" // address of _meta (operand syntax differs per target)
+        ".popsection" :: "S"(&_meta));
 ----
 
-Access to this elf section is possible via the following code;
+Access to this elf section is possible via the linker-generated start/stop symbols:
 [source,C,linenums]
 ----
-extern const void __start_my_section;
-extern const void __stop_my_section;
+extern const void *const __start__clltk_MYBUFFER_metaptr;
+extern const void *const __stop__clltk_MYBUFFER_metaptr;
 
-const void *const begin = &__start_my_section;  // pointer to first address of my_section
-const void *const end = &__stop_my_section;     // pointer to first address after my_section
+// iterate all meta pointers of the buffer
+for (const void *const *p = &__start__clltk_MYBUFFER_metaptr;
+     p < &__stop__clltk_MYBUFFER_metaptr; p++) {
+    register_meta_entry(*p); // each entry is self-describing (magic + size prefix)
+}
 ----
 ---
 === caching process and thread id

--- a/docs/technical_documentation.asciidoc
+++ b/docs/technical_documentation.asciidoc
@@ -123,8 +123,11 @@ printf_like_function(receiver, "%d", (long)1); // gcc warning [-Wformat]
 
 === Gathering meta data at compile-time
 Each tracepoint's meta data is created as an ordinary `static const` struct at the call site.
-To make all tracepoints of one tracebuffer discoverable at startup, a pointer to each meta
-struct is collected in a custom elf-section named `_clltk_<BUFFER>_metaptr`.
+To make all tracepoints of one tracebuffer discoverable at startup, every call site emits a
+pointer pair into a custom elf-section named `_clltk_<BUFFER>_metaptr`: the address of the meta
+struct and the address of the call site's file-offset cache. During startup registration the
+constructor writes the resolved file offset into the cache, so the first execution of a
+tracepoint does not need any lookup.
 
 The pointer is emitted with an inline-assembly data directive instead of the
 link:https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html[gcc section attribute].
@@ -139,11 +142,13 @@ C and C++.
 ----
 // at every tracepoint call site (simplified):
 static const struct { ... } _meta __attribute__((used)) = { ... };
+static _clltk_file_offset_t _clltk_offset = _clltk_file_offset_unset;
 
 __asm__(".pushsection _clltk_MYBUFFER_metaptr,\"a\"\n\t"
         ".balign 8\n\t"
         ".dc.a %c0\n\t" // address of _meta (operand syntax differs per target)
-        ".popsection" :: "S"(&_meta));
+        ".dc.a %c1\n\t" // address of _clltk_offset
+        ".popsection" :: "S"(&_meta), "S"(&_clltk_offset));
 ----
 
 Access to this elf section is possible via the linker-generated start/stop symbols:
@@ -152,10 +157,12 @@ Access to this elf section is possible via the linker-generated start/stop symbo
 extern const void *const __start__clltk_MYBUFFER_metaptr;
 extern const void *const __stop__clltk_MYBUFFER_metaptr;
 
-// iterate all meta pointers of the buffer
+// iterate all {meta, offset cache} pairs of the buffer
 for (const void *const *p = &__start__clltk_MYBUFFER_metaptr;
-     p < &__stop__clltk_MYBUFFER_metaptr; p++) {
-    register_meta_entry(*p); // each entry is self-describing (magic + size prefix)
+     p + 1 < &__stop__clltk_MYBUFFER_metaptr; p += 2) {
+    // p[0] is self-describing (magic + size prefix); the resolved file
+    // offset is written into the cache at p[1]
+    *(_clltk_file_offset_t *)p[1] = register_meta_entry(p[0]);
 }
 ----
 ---

--- a/examples/complex_cpp/complex_cpp.cpp
+++ b/examples/complex_cpp/complex_cpp.cpp
@@ -177,11 +177,6 @@ void typedef_example(void)
 	CLLTK_TRACEPOINT(COMPLEX_CPP, "%u", value);
 }
 
-#if defined(__GNUC__) && (__GNUC__ < 15)
-void inline_functions(void)
-{ /* not working with gcc < 15 */
-}
-#else
 CLLTK_TRACEBUFFER(INLINE_FUNCTIONS_CPP, 4096);
 inline void inline_func(void)
 {
@@ -218,7 +213,6 @@ void inline_functions(void)
 	inline_func();
 	static_inline_func();
 }
-#endif
 
 CLLTK_TRACEBUFFER(NAMESPACE_FUNCTIONS, 4096);
 namespace test

--- a/kernel_tracing_library/src/Kbuild
+++ b/kernel_tracing_library/src/Kbuild
@@ -5,7 +5,12 @@ ccflags-y := \
 	-D _CLLTK_INTERNAL=1 \
 	-finline-functions \
 	-funroll-loops \
-	-I$(src) 
+	-I$(src)
+
+# gcc lowers _Atomic/__atomic to libgcc outline-atomics calls on aarch64
+# (__aarch64_ldadd8_acq_rel, ...) which do not exist in kernel space; force
+# inline atomic sequences instead. No-op on other architectures.
+ccflags-y += $(call cc-option,-mno-outline-atomics)
 
 # kernel module
 obj-m := clltk_kernel_tracing.o

--- a/scripts/ci-cd/build_kernelspace.sh
+++ b/scripts/ci-cd/build_kernelspace.sh
@@ -112,7 +112,12 @@ prepare_kernel() {
         log "Creating kernel configuration"
         make defconfig
 
-        # Required for CLLTK kernel module
+        # Required for CLLTK kernel module. Registration runs from module
+        # gcc constructors, which the kernel only executes with
+        # CONFIG_CONSTRUCTORS - not user-selectable, pulled in via GCOV.
+        ./scripts/config --set-val CONFIG_DEBUG_FS y
+        ./scripts/config --set-val CONFIG_GCOV_KERNEL y
+        ./scripts/config --set-val CONFIG_CONSTRUCTORS y
         ./scripts/config --set-val CONFIG_MODULES y
         ./scripts/config --set-val CONFIG_MODULE_UNLOAD y
         ./scripts/config --set-val CONFIG_KALLSYMS y
@@ -443,7 +448,7 @@ if [[ "$RUN_QEMU" == "true" ]]; then
     rm -rf "$INITRD_DIR"
     INITRD=$(create_initramfs "$INITRD_DIR" "$TRACES_DIR" "${KO_FILES[@]}")
 
-    if run_qemu_test "$BZIMAGE" "$INITRD" "$TRACES_DIR"; then
+    if run_qemu_test "$BZIMAGE" "$INITRD" "$TRACES_DIR" "${CLLTK_QEMU_TIMEOUT:-120}"; then
         # Decode traces
         DECODER="$ROOT_PATH/decoder_tool/python/clltk_decoder.py"
         if [[ -f "$DECODER" ]]; then

--- a/scripts/ci-cd/step_build_kernel_module.sh
+++ b/scripts/ci-cd/step_build_kernel_module.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024, International Business Machines
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+# CI Step: Build the kernel modules against the distro kernel headers.
+#
+# This is a compile-and-link check (including modpost symbol resolution),
+# not a runtime test - for that see test_kernelspace.sh, which boots a
+# QEMU kernel. Linking matters: the module can compile per-object but
+# fail modpost, e.g. when gcc emits libgcc calls that do not exist in
+# kernel space (outline atomics on aarch64).
+#
+# Exit: 0 = success, 1 = build failed
+
+set -euo pipefail
+
+ROOT_PATH=$(git rev-parse --show-toplevel)
+cd "${ROOT_PATH}"
+
+echo "========================================"
+echo "CI Step: Build Kernel Modules"
+echo "========================================"
+
+if ! ls /usr/src/kernels/*/Makefile >/dev/null 2>&1; then
+    echo "Installing kernel-devel..."
+    dnf -y install kernel-devel flex bison elfutils-libelf-devel openssl-devel bc >/dev/null
+fi
+KDIR=$(ls -d /usr/src/kernels/* | head -1)
+echo "Kernel tree: $KDIR"
+
+echo ""
+echo "Building clltk_kernel_tracing..."
+# cd instead of make -C: the module Makefile derives repo paths from $(PWD).
+# It generates version.gen.h itself.
+if ! (cd kernel_tracing_library/src && make KERNEL_SRC="$KDIR" modules); then
+    echo "FAILED: kernel tracing module build failed"
+    exit 1
+fi
+
+echo ""
+echo "Building simple_kernel_module example..."
+if ! make -C "$KDIR" M="$ROOT_PATH/examples/simple_kernel_module" \
+        KBUILD_EXTRA_SYMBOLS="$ROOT_PATH/kernel_tracing_library/src/Module.symvers" modules; then
+    echo "FAILED: example kernel module build failed"
+    exit 1
+fi
+
+echo ""
+echo "PASSED: kernel modules build and link"
+exit 0

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -64,81 +64,84 @@ if ! image_exists "$TAG"; then
     fi
 fi
 
-container_cmd="${CONTAINER_CMD} run"
+# build the container invocation as an argument array: no eval, so paths with
+# spaces and forwarded commands with arbitrary quoting/newlines stay intact
+container_args=(run)
 container_workdir="/clltk-workspace-base"
-container_cmd+=" --workdir $container_workdir/"
+container_args+=(--workdir "$container_workdir/")
 
 if [[ "${READ_ONLY_CONTAINER:-false}" == "true" ]]; then
     # add source folder as read only
-    container_cmd+=" --volume ${ROOT_PATH}/:$container_workdir/:roz"
-    container_cmd+=" --read-only"
+    container_args+=(--volume "${ROOT_PATH}/:$container_workdir/:roz")
+    container_args+=(--read-only)
 else
     # or add source folder as writable
-    container_cmd+=" --volume ${ROOT_PATH}/:$container_workdir/:z"
+    container_args+=(--volume "${ROOT_PATH}/:$container_workdir/:z")
 fi
 
 if [[ -d "${HOME}/.ccache/" ]]; then
-    container_cmd+=" --volume ${HOME}/.ccache:/root/.ccache/"
-    container_cmd+=" --env CCACHE_DIR=/root/.ccache/"
+    container_args+=(--volume "${HOME}/.ccache:/root/.ccache/")
+    container_args+=(--env CCACHE_DIR=/root/.ccache/)
 fi
 
 catch_dir=./build/in_container/$CONTAINER_ARCH
-mkdir -p $catch_dir
+mkdir -p "$catch_dir"
 
-mkdir -p $catch_dir/build
-container_cmd+=" --env BUILD_DIR=$container_workdir/build/"
-container_cmd+=" --volume $catch_dir/build/:$container_workdir/build/:z"
+mkdir -p "$catch_dir/build"
+container_args+=(--env "BUILD_DIR=$container_workdir/build/")
+container_args+=(--volume "$catch_dir/build/:$container_workdir/build/:z")
 
-mkdir -p $catch_dir/build/install
-container_cmd+=" --env INSTALL_DIR=$container_workdir/build/install/"
+mkdir -p "$catch_dir/build/install"
+container_args+=(--env "INSTALL_DIR=$container_workdir/build/install/")
 
 if [ -n "${SONAR_TOKEN}" ]; then
-    container_cmd+=" --env SONAR_TOKEN=${SONAR_TOKEN}"
+    container_args+=(--env "SONAR_TOKEN=${SONAR_TOKEN}")
 fi
 
 if [[ ! -z $PERSITENT_ARTIFACTS ]]; then
-    container_cmd+=" --volume ${PERSITENT_ARTIFACTS}:$container_workdir/build_kernel/persistent/:z"
+    container_args+=(--volume "${PERSITENT_ARTIFACTS}:$container_workdir/build_kernel/persistent/:z")
 else
-    mkdir -p $catch_dir/build_kernel/persistent
+    mkdir -p "$catch_dir/build_kernel/persistent"
 fi
-container_cmd+=" --env PERSITENT_ARTIFACTS=$container_workdir/build_kernel/persistent/"
+container_args+=(--env "PERSITENT_ARTIFACTS=$container_workdir/build_kernel/persistent/")
 
-mkdir -p $catch_dir/traces/
-container_cmd+=" --env CLLTK_TRACING_PATH=/tmp/traces/"
-container_cmd+=" --volume $catch_dir/traces:/tmp/traces/:z"
+mkdir -p "$catch_dir/traces/"
+container_args+=(--env CLLTK_TRACING_PATH=/tmp/traces/)
+container_args+=(--volume "$catch_dir/traces:/tmp/traces/:z")
 
-touch $catch_dir/../.bash_history
-container_cmd+=" --volume $catch_dir/../.bash_history:/root/.bash_history:z"
+touch "$catch_dir/../.bash_history"
+container_args+=(--volume "$catch_dir/../.bash_history:/root/.bash_history:z")
 
-container_cmd+=" --security-opt label=disable"
-container_cmd+=" --security-opt=seccomp=unconfined"
-container_cmd+=" --user root"
+container_args+=(--security-opt label=disable)
+container_args+=(--security-opt=seccomp=unconfined)
+container_args+=(--user root)
 
 # forward pull request info
-container_cmd+=" --env CLLTK_CI_VERSION_STEP_REQUIRED=${CLLTK_CI_VERSION_STEP_REQUIRED:-"true"}"
+container_args+=(--env "CLLTK_CI_VERSION_STEP_REQUIRED=${CLLTK_CI_VERSION_STEP_REQUIRED:-true}")
 
 # container run option
-container_cmd+=" --entrypoint /bin/bash"
-container_cmd+=" --network=host"
-container_cmd+=" --hostname clltk-ci"
-container_cmd+=" --rm"
+container_args+=(--entrypoint /bin/bash)
+container_args+=(--network=host)
+container_args+=(--hostname clltk-ci)
+container_args+=(--rm)
 
 # Add interactive flags unless running in non-interactive mode (e.g. CI)
 # Auto-detect: skip --interactive --tty when stdin is not a terminal
 if [[ "${CONTAINER_NON_INTERACTIVE:-false}" != "true" ]] && [ -t 0 ]; then
-    container_cmd+=" --interactive --tty"
+    container_args+=(--interactive --tty)
 fi
 
-container_cmd+=" $TAG"
+container_args+=("$TAG")
 
-# forward into container 
+# forward into container
 if [ $# -ne 0 ]; then
-    # Run the provided command
-    container_cmd+=" -c \"$(printf '%q ' "$@")\""
+    # Run the provided command: %q-quote every argument into one string that
+    # the container's bash -c unquotes again, preserving the exact arguments
+    container_args+=(-c "$(printf '%q ' "$@")")
 else
     # Interactive shell
-    container_cmd+=" --login -i"
+    container_args+=(--login -i)
 fi
 
-echo run = "$container_cmd"
-eval "$container_cmd" # run the command
+echo run = "$CONTAINER_CMD ${container_args[*]}"
+exec "$CONTAINER_CMD" "${container_args[@]}"

--- a/tests/packaging/helpers/rpm.py
+++ b/tests/packaging/helpers/rpm.py
@@ -47,6 +47,15 @@ def packages_exist() -> bool:
 
 def ensure_rpms_built() -> None:
     """Build RPMs if they don't exist yet."""
+    # remove packages from other versions first: they would either satisfy the
+    # existence check with stale artifacts or sit next to the current packages
+    # and get picked up by filename-based lookups
+    pkg_dir = get_packages_dir()
+    if pkg_dir.is_dir():
+        version = get_version_string()
+        for rpm in pkg_dir.glob("*.rpm"):
+            if f"-{version}-" not in rpm.name:
+                rpm.unlink()
     if packages_exist():
         return
     root = get_repo_root()

--- a/tests/packaging/helpers/rpm.py
+++ b/tests/packaging/helpers/rpm.py
@@ -28,7 +28,7 @@ EXPECTED_RPM_PATTERNS = [
 
 
 def packages_exist() -> bool:
-    """Check if all expected RPM packages have been built."""
+    """Check if all expected RPM packages have been built for the current version."""
     pkg_dir = get_packages_dir()
     if not pkg_dir.is_dir():
         return False
@@ -36,8 +36,11 @@ def packages_exist() -> bool:
     if not rpm_names:
         return False
     # Check that every expected subpackage has at least one matching RPM
+    # carrying the version from VERSION.md. Without the version check, stale
+    # artifacts from a previously built version would be reused and tested.
+    version = get_version_string()
     for pattern in EXPECTED_RPM_PATTERNS:
-        if not any(pattern in name for name in rpm_names):
+        if not any(name.startswith(f"{pattern}{version}-") for name in rpm_names):
             return False
     return True
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -78,10 +78,15 @@ class complex_c(ExamplesTestCase):
         data: pd.DataFrame = self.decoded
         DESTRUCTOR = data[data.tracebuffer == "DESTRUCTOR"]
         formatted = DESTRUCTOR["formatted"].tolist()
-        self.assertNotIn("destructor101", formatted)
+        # destructors with priority > 101 reliably trace
         self.assertIn("destructor102", formatted)
         self.assertIn("destructor103", formatted)
-        self.assertEqual(2 + TRACEBUFFER_INFO_COUNT, len(DESTRUCTOR))
+        # a destructor at priority exactly 101 races clltk's own teardown
+        # destructor (also priority 101): same-priority .fini_array order is
+        # emission-order dependent (LTO flips it), so destructor101 may or may
+        # not be traced. Both outcomes are valid; assert nothing about it.
+        expected_reliable = 2 + TRACEBUFFER_INFO_COUNT
+        self.assertIn(len(DESTRUCTOR), (expected_reliable, expected_reliable + 1))
         pass
 
     pass
@@ -131,12 +136,17 @@ class complex_cpp(ExamplesTestCase):
         data: pd.DataFrame = self.decoded
         DESTRUCTOR = data[data.tracebuffer == "DESTRUCTOR_CPP"]
         formatted = DESTRUCTOR["formatted"].tolist()
-        self.assertNotIn("void destructor101()", formatted)
+        # destructors with priority > 101 reliably trace
         self.assertIn("void destructor102()", formatted)
         self.assertIn("void destructor103()", formatted)
         self.assertIn("TestClass::TestClass()", formatted)
         self.assertIn("TestClass::~TestClass()", formatted)
-        self.assertEqual(4 + TRACEBUFFER_INFO_COUNT, len(DESTRUCTOR))
+        # a destructor at priority exactly 101 races clltk's own teardown
+        # destructor (also priority 101): same-priority .fini_array order is
+        # emission-order dependent (LTO flips it), so destructor101 may or may
+        # not be traced. Both outcomes are valid; assert nothing about it.
+        expected_reliable = 4 + TRACEBUFFER_INFO_COUNT
+        self.assertIn(len(DESTRUCTOR), (expected_reliable, expected_reliable + 1))
         pass
 
     pass

--- a/tests/test_meta_cmd.py
+++ b/tests/test_meta_cmd.py
@@ -383,5 +383,66 @@ class TestMetaFilterOptions(MetaTestCase):
         self.assertNotIn("CaseSensitive", result.stdout)
 
 
+class TestMetaFromElf(MetaTestCase):
+    """Tests reading tracepoint metadata directly from ELF files.
+
+    Covers both a linked executable (pointer slots hold virtual addresses)
+    and a relocatable object file (pointer slots are zero and the meta
+    locations come from the relocation records).
+    """
+
+    SOURCE = """
+        #include "CommonLowLevelTracingKit/tracing/tracing.h"
+        CLLTK_TRACEBUFFER(ELF_META_TEST, 4096);
+        void traced_function(void)
+        {
+            CLLTK_TRACEPOINT(ELF_META_TEST, "elf meta test tracepoint %d", 42);
+        }
+        int main(void)
+        {
+            traced_function();
+            return 0;
+        }
+        """
+
+    def setUp(self):
+        super().setUp()
+        repo_root = pathlib.Path(__file__).parent.parent
+        include_dir = repo_root / "tracing_library" / "include"
+        self.source_file = pathlib.Path(self.tmp_dir.name) / "elf_meta.c"
+        self.source_file.write_text(self.SOURCE)
+        self.include_flag = f"-I{include_dir}"
+
+    def _compile(self, *extra_args: str) -> None:
+        result = run_command(
+            f"gcc -std=c11 {self.include_flag} " + " ".join(extra_args),
+            cwd=self.tmp_dir.name,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_meta_from_linked_executable(self):
+        """Meta entries are readable from a linked (but never run) binary."""
+        # compile only up to an executable; the library is not needed because
+        # main never runs, but linking needs the runtime symbols, so link the
+        # object into a shared library instead (fully linked, has addresses)
+        self._compile("-fPIC -shared elf_meta.c -o elf_meta.so")
+
+        result = clltk("meta", str(pathlib.Path(self.tmp_dir.name) / "elf_meta.so"))
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("ELF_META_TEST", result.stdout)
+        self.assertIn("elf meta test tracepoint %d", result.stdout)
+
+    def test_meta_from_relocatable_object(self):
+        """Meta entries are readable from a .o file via relocation records."""
+        self._compile("-c elf_meta.c -o elf_meta.o")
+
+        result = clltk("meta", str(pathlib.Path(self.tmp_dir.name) / "elf_meta.o"))
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("ELF_META_TEST", result.stdout)
+        self.assertIn("elf meta test tracepoint %d", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_valid_build.py
+++ b/tests/test_valid_build.py
@@ -67,6 +67,77 @@ class valid_build_tests(unittest.TestCase):
                 self.assertLess(len(data[data["formatted"] == "42"]), 10)
                 pass
 
+    def test_tracepoint_in_comdat_and_plain_function_same_buffer(self: unittest.TestCase):
+        """Regression test for the GCC >= 15.2 hard error:
+
+            error: '_meta' causes a section type conflict with '_meta'
+                   in section '_clltk_BUFFER_meta'
+
+        A tracepoint inside a COMDAT context (inline function, function
+        template, or class template member) places its meta object into a
+        COMDAT-grouped ELF section, while a tracepoint in a plain function
+        uses an ungrouped section of the same name. GCC 15.2+ refuses to mix
+        the two in one translation unit. This only reproduces without LTO,
+        which is how consumers compile against the installed headers.
+        """
+        common_part = """
+            #include "CommonLowLevelTracingKit/tracing/tracing.h"
+            CLLTK_TRACEBUFFER(BUFFER, 4096);
+            void plain_function(void)
+            {
+                CLLTK_TRACEPOINT(BUFFER, "plain, longer format string %u", 42u);
+            }
+            """
+        comdat_cases = {
+            "inline function": """
+                inline void comdat_function(void)
+                {
+                    CLLTK_TRACEPOINT(BUFFER, "comdat %d", 1);
+                }
+                int main(void)
+                {
+                    comdat_function();
+                    plain_function();
+                    return 0;
+                }
+                """,
+            "function template": """
+                template <typename T> void comdat_function(T value)
+                {
+                    CLLTK_TRACEPOINT(BUFFER, "comdat %d", (int)value);
+                }
+                int main(void)
+                {
+                    comdat_function(1);
+                    plain_function();
+                    return 0;
+                }
+                """,
+            "class template member": """
+                template <typename T> struct Wrapper
+                {
+                    static void trace(void)
+                    {
+                        CLLTK_TRACEPOINT(BUFFER, "comdat %d", 1);
+                    }
+                };
+                int main(void)
+                {
+                    Wrapper<int>::trace();
+                    plain_function();
+                    return 0;
+                }
+                """,
+        }
+        for case_name, comdat_part in comdat_cases.items():
+            with self.subTest(case=case_name):
+                data = process(common_part + comdat_part, language=Language.CPP)
+                self.assertEqual(len(data[data["formatted"] == "comdat 1"]), 1)
+                self.assertEqual(
+                    len(data[data["formatted"] == "plain, longer format string 42"]), 1
+                )
+                pass
+
     def test_empty(self: unittest.TestCase):
         for language in [Language.C, Language.CPP]:
             with self.subTest(language=language):

--- a/tests/tracing.tests/meta.tests/meta_macro.tests.cpp
+++ b/tests/tracing.tests/meta.tests/meta_macro.tests.cpp
@@ -13,7 +13,8 @@ TEST(meta_macro, str)
 	volatile char arg0[] = "arg0 string";
 	CLLTK_TRACEPOINT(META_MACRO_00, "arg0 = %s", arg0);
 	const static uint32_t ref_line = __LINE__;
-	const char *const meta = (const char *)_clltk_META_MACRO_00.meta.start;
+	// the meta section holds pointers to the meta entries
+	const char *const meta = ((const char *const *)_clltk_META_MACRO_00.meta.start)[0];
 	const char magic = *reinterpret_cast<const char *>(&meta[0]);
 	const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
 	const _clltk_meta_enty_type type = *reinterpret_cast<const _clltk_meta_enty_type *>(&meta[5]);
@@ -42,7 +43,8 @@ TEST(meta_macro, str_str)
 	volatile char arg1[] = "arg1 string";
 	CLLTK_TRACEPOINT(META_MACRO_01, "arg0 = %s arg1 = %s", arg0, arg1);
 	const static uint32_t ref_line = __LINE__;
-	const char *const meta = (const char *)_clltk_META_MACRO_01.meta.start;
+	// the meta section holds pointers to the meta entries
+	const char *const meta = ((const char *const *)_clltk_META_MACRO_01.meta.start)[0];
 	const char magic = *reinterpret_cast<const char *>(&meta[0]);
 	const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
 	const _clltk_meta_enty_type type = *reinterpret_cast<const _clltk_meta_enty_type *>(&meta[5]);
@@ -71,7 +73,8 @@ TEST(meta_macro, int64)
 	volatile int64_t arg0 = -1;
 	CLLTK_TRACEPOINT(META_MACRO_02, "arg0 = %ld", arg0);
 	const static uint32_t ref_line = __LINE__;
-	const char *const meta = (const char *)_clltk_META_MACRO_02.meta.start;
+	// the meta section holds pointers to the meta entries
+	const char *const meta = ((const char *const *)_clltk_META_MACRO_02.meta.start)[0];
 	const char magic = *reinterpret_cast<const char *>(&meta[0]);
 	const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
 	const _clltk_meta_enty_type type = *reinterpret_cast<const _clltk_meta_enty_type *>(&meta[5]);
@@ -97,7 +100,9 @@ CLLTK_TRACEBUFFER(META_MACRO_03, 1024)
 TEST(meta_macro, two_tracepoints)
 {
 
-	const char *meta = (const char *)_clltk_META_MACRO_03.meta.start;
+	// the meta section holds one pointer per tracepoint, in emission order
+	const char *const *const meta_ptrs = (const char *const *)_clltk_META_MACRO_03.meta.start;
+	const char *meta = meta_ptrs[0];
 	{
 		volatile int64_t arg0 = -1;
 		CLLTK_TRACEPOINT(META_MACRO_03, "arg0 = %ld", arg0);
@@ -123,11 +128,7 @@ TEST(meta_macro, two_tracepoints)
 		EXPECT_EQ(arg_types[arg_count], 0);
 		EXPECT_STRCASEEQ(meta_file_name, __FILE__);
 		EXPECT_STRCASEEQ(meta_format, "arg0 = %ld");
-		meta += size;
-		size_t offset = 0;
-		for (offset = 0; meta[offset] == '\0'; offset++)
-			;
-		meta += offset;
+		meta = meta_ptrs[1];
 	}
 	{
 		volatile int64_t arg0 = -1;
@@ -154,7 +155,6 @@ TEST(meta_macro, two_tracepoints)
 		EXPECT_EQ(arg_types[arg_count], 0);
 		EXPECT_STRCASEEQ(meta_file_name, __FILE__);
 		EXPECT_STRCASEEQ(meta_format, "arg0 = %ld");
-		meta += size;
 	}
 }
 
@@ -162,7 +162,9 @@ CLLTK_TRACEBUFFER(META_MACRO_04, 1024)
 TEST(meta_macro, three_tracepoints)
 {
 
-	const char *meta = (const char *)_clltk_META_MACRO_04.meta.start;
+	// the meta section holds one pointer per tracepoint, in emission order
+	const char *const *const meta_ptrs = (const char *const *)_clltk_META_MACRO_04.meta.start;
+	const char *meta = meta_ptrs[0];
 	{
 		int64_t arg0 = -1;
 		CLLTK_TRACEPOINT(META_MACRO_04, "arg0 = %ld", arg0);
@@ -171,11 +173,7 @@ TEST(meta_macro, three_tracepoints)
 
 		EXPECT_EQ(magic, '{');
 		EXPECT_EQ(size, 25 + strlen(__FILE__));
-		meta += size;
-		size_t offset = 0;
-		for (offset = 0; meta[offset] == '\0'; offset++)
-			;
-		meta += offset;
+		meta = meta_ptrs[1];
 	}
 	{
 		volatile char arg0[] = "Hello World!\n";
@@ -184,11 +182,8 @@ TEST(meta_macro, three_tracepoints)
 		const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
 
 		EXPECT_EQ(magic, '{');
-		meta += size;
-		size_t offset = 0;
-		for (offset = 0; meta[offset] == '\0'; offset++)
-			;
-		meta += offset;
+		EXPECT_GT(size, 0u);
+		meta = meta_ptrs[2];
 	}
 	{
 		volatile double arg0 = 3e-23;
@@ -197,6 +192,6 @@ TEST(meta_macro, three_tracepoints)
 		const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
 
 		EXPECT_EQ(magic, '{');
-		meta += size;
+		EXPECT_GT(size, 0u);
 	}
 }

--- a/tests/tracing.tests/meta.tests/meta_macro.tests.cpp
+++ b/tests/tracing.tests/meta.tests/meta_macro.tests.cpp
@@ -13,7 +13,7 @@ TEST(meta_macro, str)
 	volatile char arg0[] = "arg0 string";
 	CLLTK_TRACEPOINT(META_MACRO_00, "arg0 = %s", arg0);
 	const static uint32_t ref_line = __LINE__;
-	// the meta section holds pointers to the meta entries
+	// the meta section holds {meta, offset-cache} pointer pairs per tracepoint
 	const char *const meta = ((const char *const *)_clltk_META_MACRO_00.meta.start)[0];
 	const char magic = *reinterpret_cast<const char *>(&meta[0]);
 	const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
@@ -43,7 +43,7 @@ TEST(meta_macro, str_str)
 	volatile char arg1[] = "arg1 string";
 	CLLTK_TRACEPOINT(META_MACRO_01, "arg0 = %s arg1 = %s", arg0, arg1);
 	const static uint32_t ref_line = __LINE__;
-	// the meta section holds pointers to the meta entries
+	// the meta section holds {meta, offset-cache} pointer pairs per tracepoint
 	const char *const meta = ((const char *const *)_clltk_META_MACRO_01.meta.start)[0];
 	const char magic = *reinterpret_cast<const char *>(&meta[0]);
 	const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
@@ -73,7 +73,7 @@ TEST(meta_macro, int64)
 	volatile int64_t arg0 = -1;
 	CLLTK_TRACEPOINT(META_MACRO_02, "arg0 = %ld", arg0);
 	const static uint32_t ref_line = __LINE__;
-	// the meta section holds pointers to the meta entries
+	// the meta section holds {meta, offset-cache} pointer pairs per tracepoint
 	const char *const meta = ((const char *const *)_clltk_META_MACRO_02.meta.start)[0];
 	const char magic = *reinterpret_cast<const char *>(&meta[0]);
 	const uint32_t size = *reinterpret_cast<const uint32_t *>(&meta[1]);
@@ -100,7 +100,8 @@ CLLTK_TRACEBUFFER(META_MACRO_03, 1024)
 TEST(meta_macro, two_tracepoints)
 {
 
-	// the meta section holds one pointer per tracepoint, in emission order
+	// the meta section holds {meta, offset-cache} pointer pairs per
+	// tracepoint, in emission order
 	const char *const *const meta_ptrs = (const char *const *)_clltk_META_MACRO_03.meta.start;
 	const char *meta = meta_ptrs[0];
 	{
@@ -128,7 +129,7 @@ TEST(meta_macro, two_tracepoints)
 		EXPECT_EQ(arg_types[arg_count], 0);
 		EXPECT_STRCASEEQ(meta_file_name, __FILE__);
 		EXPECT_STRCASEEQ(meta_format, "arg0 = %ld");
-		meta = meta_ptrs[1];
+		meta = meta_ptrs[2];
 	}
 	{
 		volatile int64_t arg0 = -1;
@@ -162,7 +163,8 @@ CLLTK_TRACEBUFFER(META_MACRO_04, 1024)
 TEST(meta_macro, three_tracepoints)
 {
 
-	// the meta section holds one pointer per tracepoint, in emission order
+	// the meta section holds {meta, offset-cache} pointer pairs per
+	// tracepoint, in emission order
 	const char *const *const meta_ptrs = (const char *const *)_clltk_META_MACRO_04.meta.start;
 	const char *meta = meta_ptrs[0];
 	{
@@ -173,7 +175,7 @@ TEST(meta_macro, three_tracepoints)
 
 		EXPECT_EQ(magic, '{');
 		EXPECT_EQ(size, 25 + strlen(__FILE__));
-		meta = meta_ptrs[1];
+		meta = meta_ptrs[2];
 	}
 	{
 		volatile char arg0[] = "Hello World!\n";
@@ -183,7 +185,7 @@ TEST(meta_macro, three_tracepoints)
 
 		EXPECT_EQ(magic, '{');
 		EXPECT_GT(size, 0u);
-		meta = meta_ptrs[2];
+		meta = meta_ptrs[4];
 	}
 	{
 		volatile double arg0 = 3e-23;

--- a/tracing_library/include/CommonLowLevelTracingKit/tracing/_internal.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/tracing/_internal.h
@@ -65,6 +65,16 @@ _clltk_file_offset_t _clltk_tracebuffer_get_in_file_offset(_clltk_tracebuffer_ha
 														   const uint32_t this_meta_size)
 	__attribute__((nonnull(1), used, visibility("default")));
 
+/* register all discovery entries of one tracebuffer at once. pairs_start and
+ * pairs_stop delimit the _clltk_<BUFFER>_metaptr section content: pointer
+ * pairs of {meta entry, file-offset cache}. Entries whose cache is already
+ * set are skipped; caches of successfully registered entries are filled with
+ * the resolved file offset. */
+void _clltk_tracebuffer_register_metaptrs(_clltk_tracebuffer_handler_t *buffer,
+										  const void *const *pairs_start,
+										  const void *const *pairs_stop)
+	__attribute__((nonnull(1), used, visibility("default")));
+
 void _clltk_static_tracepoint_with_dump(_clltk_tracebuffer_handler_t *buffer,
 										const _clltk_file_offset_t in_file_offset,
 										const char *const file, const uint32_t line,

--- a/tracing_library/include/CommonLowLevelTracingKit/tracing/_macros.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/tracing/_macros.h
@@ -35,7 +35,14 @@
 #if defined(__KERNEL__)
 #define _CLLTK_PLACE_IN(_NAME_)
 #else
-#define _CLLTK_PLACE_IN(_NAME_) __attribute__((used, section("_clltk_" #_NAME_ "_meta")))
+/* Meta objects are ordinary statics; discovery happens through pointers
+ * emitted into the _clltk_<NAME>_metaptr section (see _CLLTK_EMIT_META_PTR
+ * in _user_tracing.h). Placing the object itself into a named section via
+ * the section attribute would join the enclosing function's COMDAT group
+ * inside inline functions and templates, and GCC (>= 15.2) rejects mixing
+ * grouped and ungrouped sections of the same name in one translation unit:
+ * "causes a section type conflict". */
+#define _CLLTK_PLACE_IN(_NAME_) __attribute__((used))
 #endif
 
 #if defined(__cplusplus)

--- a/tracing_library/include/CommonLowLevelTracingKit/tracing/_meta.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/tracing/_meta.h
@@ -27,6 +27,14 @@ typedef enum __attribute__((packed)) {
 } _clltk_meta_enty_type;
 _CLLTK_STATIC_ASSERT(sizeof(_clltk_meta_enty_type) == 1, "should be of size 1");
 
+/* fixed prefix shared by every meta entry created below: magic byte followed
+ * by the total entry size. Used to walk pointer-discovered meta entries. */
+typedef struct __attribute__((packed, aligned(1))) {
+	const char magic;
+	const uint32_t size;
+} _clltk_meta_entry_head_t;
+_CLLTK_STATIC_ASSERT(sizeof(_clltk_meta_entry_head_t) == 5, "should be of size 5");
+
 #define _CLLTK_CREATE_META_ENTRY_ARGS(_VAR_, _ATTRIBUTE_, _STR_, ...)                            \
                                                                                                  \
 	_CLLTK_STATIC_ASSERT(__LINE__ <= UINT32_MAX, "line fits not in uint32");                     \

--- a/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
@@ -53,25 +53,10 @@ __attribute__((constructor(101), used)) static void _clltk_constructor(void)
 		if (!_clltk_tracebuffer_init(handler)) {
 			continue;
 		}
-		for (const uint8_t *const *entry_ptr = meta_start; entry_ptr + 1 < meta_stop;
-			 entry_ptr += 2) {
-			const _clltk_meta_entry_head_t *const head =
-				(const _clltk_meta_entry_head_t *)entry_ptr[0];
-			_clltk_file_offset_t *const offset_cache =
-				(_clltk_file_offset_t *)(uintptr_t)entry_ptr[1];
-			if (*offset_cache != _clltk_file_offset_unset) {
-				/* already registered, e.g. by another translation unit's
-				 * constructor walking the same merged section */
-				continue;
-			}
-			/* duplicates (e.g. from inlined call sites) are deduplicated by
-			 * the unique stack, which returns the existing offset */
-			const _clltk_file_offset_t offset =
-				_clltk_tracebuffer_add_to_stack(handler, entry_ptr[0], head->size);
-			if (_CLLTK_FILE_OFFSET_IS_STATIC(offset)) {
-				*offset_cache = offset;
-			}
-		}
+		/* registers all entries in one batch and fills each call site's
+		 * offset cache; already-resolved entries are skipped */
+		_clltk_tracebuffer_register_metaptrs(handler, (const void *const *)meta_start,
+											 (const void *const *)meta_stop);
 	}
 }
 

--- a/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
@@ -42,17 +42,22 @@ __attribute__((constructor(101), used)) static void _clltk_constructor(void)
 	for (_clltk_tracebuffer_handler_t *const *handler_ptr = &__start__clltk_tracebuffer_handler_ptr;
 		 handler_ptr < &__stop__clltk_tracebuffer_handler_ptr; handler_ptr++) {
 		_clltk_tracebuffer_handler_t *const handler = *handler_ptr;
-		const uint32_t meta_size =
-			(uint32_t)((uint64_t)handler->meta.stop - (uint64_t)handler->meta.start);
-		if (meta_size <= 0) {
+		/* the discovery section holds pointers to the meta entries; the
+		 * entries themselves are ordinary statics (see _CLLTK_EMIT_META_PTR) */
+		const uint8_t *const *const meta_start = (const uint8_t *const *)handler->meta.start;
+		const uint8_t *const *const meta_stop = (const uint8_t *const *)handler->meta.stop;
+		if (meta_stop <= meta_start) {
 			continue;
 		}
 		if (!_clltk_tracebuffer_init(handler)) {
 			continue;
 		}
-		if (handler->runtime.file_offset == _clltk_file_offset_unset) {
-			handler->runtime.file_offset =
-				_clltk_tracebuffer_add_to_stack(handler, handler->meta.start, meta_size);
+		for (const uint8_t *const *entry_ptr = meta_start; entry_ptr < meta_stop; entry_ptr++) {
+			const _clltk_meta_entry_head_t *const head =
+				(const _clltk_meta_entry_head_t *)*entry_ptr;
+			/* duplicates (e.g. from inlined call sites) are deduplicated by
+			 * the unique stack, which returns the existing offset */
+			_clltk_tracebuffer_add_to_stack(handler, *entry_ptr, head->size);
 		}
 	}
 }
@@ -78,16 +83,16 @@ _CLLTK_EXTERN_C_END
 
 #define _CLLTK_STATIC_TRACEBUFFER(_NAME_, _SIZE_)                                            \
 	_CLLTK_EXTERN_C_BEGIN                                                                    \
-	extern const uint8_t *const __start__clltk_##_NAME_##_meta                               \
+	extern const uint8_t *const __start__clltk_##_NAME_##_metaptr                            \
 		__attribute__((weak, visibility("hidden")));                                         \
-	extern const uint8_t *const __stop__clltk_##_NAME_##_meta                                \
+	extern const uint8_t *const __stop__clltk_##_NAME_##_metaptr                             \
 		__attribute__((weak, visibility("hidden")));                                         \
                                                                                              \
 	static _clltk_tracebuffer_handler_t _clltk_##_NAME_                                      \
 		__attribute__((used)) = {{#_NAME_, _SIZE_},                                          \
 								 {                                                           \
-									 &__start__clltk_##_NAME_##_meta,                        \
-									 &__stop__clltk_##_NAME_##_meta,                         \
+									 &__start__clltk_##_NAME_##_metaptr,                     \
+									 &__stop__clltk_##_NAME_##_metaptr,                      \
 								 },                                                          \
 								 {NULL, _clltk_file_offset_unset}};                          \
                                                                                              \
@@ -95,6 +100,33 @@ _CLLTK_EXTERN_C_END
 		__attribute__((used, section("_clltk_tracebuffer_handler_ptr"))) = &_clltk_##_NAME_; \
                                                                                              \
 	_CLLTK_EXTERN_C_END
+
+/* Emit a pointer to a tracepoint's meta object into the tracebuffer's
+ * discovery section _clltk_<BUFFER>_metaptr. An assembler data directive is
+ * used instead of __attribute__((section(...))) because the attribute would
+ * place the object into the enclosing function's COMDAT group inside inline
+ * functions and templates, and GCC (>= 15.2) rejects mixing grouped and
+ * ungrouped sections of the same name in one translation unit ("causes a
+ * section type conflict"). Assembler-emitted data never joins a COMDAT
+ * group. The constraint/operand pair to print a bare symbol address differs
+ * per target (each validated with -fPIC/-pie -Werror at -O0..-O2). */
+#if defined(__aarch64__)
+#define _CLLTK_ASM_SYM_CONSTRAINT "S"
+#define _CLLTK_ASM_SYM_OPERAND "%c0"
+#elif defined(__x86_64__)
+#define _CLLTK_ASM_SYM_CONSTRAINT "Ws"
+#define _CLLTK_ASM_SYM_OPERAND "%p0"
+#else /* s390x and other targets */
+#define _CLLTK_ASM_SYM_CONSTRAINT "i"
+#define _CLLTK_ASM_SYM_OPERAND "%c0"
+#endif
+
+#define _CLLTK_EMIT_META_PTR(_BUFFER_, _VAR_)                                                    \
+	__asm__(".pushsection _clltk_" #_BUFFER_ "_metaptr,\"a\"\n\t"                                \
+			".balign " _CLLTK_STR(__SIZEOF_POINTER__) "\n\t"                                     \
+													  ".dc.a " _CLLTK_ASM_SYM_OPERAND "\n\t"     \
+													  ".popsection" ::_CLLTK_ASM_SYM_CONSTRAINT( \
+														  &_VAR_))
 
 #define _CLLTK_STATIC_TRACEPOINT(_BUFFER_, _FORMAT_, ...)                                         \
 	do {                                                                                          \
@@ -105,8 +137,9 @@ _CLLTK_EXTERN_C_END
 		_CLLTK_CHECK_FOR_ARGUMENTS(__VA_ARGS__);                                                  \
                                                                                                   \
 		/* create meta data for this tracepoint */                                                \
-		/* and add them to section */                                                             \
+		/* and emit its address into the discovery section */                                     \
 		_CLLTK_CREATE_META_ENTRY_ARGS(_meta, _CLLTK_PLACE_IN(_BUFFER_), _FORMAT_, __VA_ARGS__);   \
+		_CLLTK_EMIT_META_PTR(_BUFFER_, _meta);                                                    \
                                                                                                   \
 		/* create type information for va_list access at runtime. */                              \
 		/* it is not possible to use meta data because there is no */                             \
@@ -138,8 +171,9 @@ _CLLTK_EXTERN_C_END
 		/* ------- compile time stuff ------- */                                                  \
                                                                                                   \
 		/* create meta data for this tracepoint */                                                \
-		/* and add them to section */                                                             \
+		/* and emit its address into the discovery section */                                     \
 		_CLLTK_CREATE_META_ENTRY_DUMP(_meta, _CLLTK_PLACE_IN(_BUFFER_), _MESSAGE_);               \
+		_CLLTK_EMIT_META_PTR(_BUFFER_, _meta);                                                    \
                                                                                                   \
 		static _clltk_tracebuffer_handler_t *const _tb = &_clltk_##_BUFFER_;                      \
                                                                                                   \

--- a/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
@@ -42,8 +42,9 @@ __attribute__((constructor(101), used)) static void _clltk_constructor(void)
 	for (_clltk_tracebuffer_handler_t *const *handler_ptr = &__start__clltk_tracebuffer_handler_ptr;
 		 handler_ptr < &__stop__clltk_tracebuffer_handler_ptr; handler_ptr++) {
 		_clltk_tracebuffer_handler_t *const handler = *handler_ptr;
-		/* the discovery section holds pointers to the meta entries; the
-		 * entries themselves are ordinary statics (see _CLLTK_EMIT_META_PTR) */
+		/* the discovery section holds pointer pairs per call site:
+		 * {meta entry, file-offset cache}; the objects themselves are
+		 * ordinary statics (see _CLLTK_EMIT_META_PTR) */
 		const uint8_t *const *const meta_start = (const uint8_t *const *)handler->meta.start;
 		const uint8_t *const *const meta_stop = (const uint8_t *const *)handler->meta.stop;
 		if (meta_stop <= meta_start) {
@@ -52,12 +53,24 @@ __attribute__((constructor(101), used)) static void _clltk_constructor(void)
 		if (!_clltk_tracebuffer_init(handler)) {
 			continue;
 		}
-		for (const uint8_t *const *entry_ptr = meta_start; entry_ptr < meta_stop; entry_ptr++) {
+		for (const uint8_t *const *entry_ptr = meta_start; entry_ptr + 1 < meta_stop;
+			 entry_ptr += 2) {
 			const _clltk_meta_entry_head_t *const head =
-				(const _clltk_meta_entry_head_t *)*entry_ptr;
+				(const _clltk_meta_entry_head_t *)entry_ptr[0];
+			_clltk_file_offset_t *const offset_cache =
+				(_clltk_file_offset_t *)(uintptr_t)entry_ptr[1];
+			if (*offset_cache != _clltk_file_offset_unset) {
+				/* already registered, e.g. by another translation unit's
+				 * constructor walking the same merged section */
+				continue;
+			}
 			/* duplicates (e.g. from inlined call sites) are deduplicated by
 			 * the unique stack, which returns the existing offset */
-			_clltk_tracebuffer_add_to_stack(handler, *entry_ptr, head->size);
+			const _clltk_file_offset_t offset =
+				_clltk_tracebuffer_add_to_stack(handler, entry_ptr[0], head->size);
+			if (_CLLTK_FILE_OFFSET_IS_STATIC(offset)) {
+				*offset_cache = offset;
+			}
 		}
 	}
 }
@@ -101,32 +114,42 @@ _CLLTK_EXTERN_C_END
                                                                                              \
 	_CLLTK_EXTERN_C_END
 
-/* Emit a pointer to a tracepoint's meta object into the tracebuffer's
- * discovery section _clltk_<BUFFER>_metaptr. An assembler data directive is
- * used instead of __attribute__((section(...))) because the attribute would
- * place the object into the enclosing function's COMDAT group inside inline
- * functions and templates, and GCC (>= 15.2) rejects mixing grouped and
- * ungrouped sections of the same name in one translation unit ("causes a
- * section type conflict"). Assembler-emitted data never joins a COMDAT
- * group. The constraint/operand pair to print a bare symbol address differs
- * per target (each validated with -fPIC/-pie -Werror at -O0..-O2). */
+/* Emit one discovery entry for a tracepoint call site into the section
+ * _clltk_<BUFFER>_metaptr. Each entry is a pointer pair:
+ *   [0] address of the call site's const meta object
+ *   [1] address of the call site's file-offset cache, which the constructor
+ *       fills during startup registration so the first tracepoint execution
+ *       needs no lookup
+ * An assembler data directive is used instead of __attribute__((section(...)))
+ * because the attribute would place the object into the enclosing function's
+ * COMDAT group inside inline functions and templates, and GCC (>= 15.2)
+ * rejects mixing grouped and ungrouped sections of the same name in one
+ * translation unit ("causes a section type conflict"). Assembler-emitted data
+ * never joins a COMDAT group. The constraint/operand pair to print a bare
+ * symbol address differs per target (each validated with -fPIC/-pie -Werror
+ * at -O0..-O2). */
 #if defined(__aarch64__)
 #define _CLLTK_ASM_SYM_CONSTRAINT "S"
-#define _CLLTK_ASM_SYM_OPERAND "%c0"
+#define _CLLTK_ASM_SYM_OPERAND(_N_) "%c" _N_
 #elif defined(__x86_64__)
 #define _CLLTK_ASM_SYM_CONSTRAINT "Ws"
-#define _CLLTK_ASM_SYM_OPERAND "%p0"
+#define _CLLTK_ASM_SYM_OPERAND(_N_) "%p" _N_
 #else /* s390x and other targets */
 #define _CLLTK_ASM_SYM_CONSTRAINT "i"
-#define _CLLTK_ASM_SYM_OPERAND "%c0"
+#define _CLLTK_ASM_SYM_OPERAND(_N_) "%c" _N_
 #endif
 
-#define _CLLTK_EMIT_META_PTR(_BUFFER_, _VAR_)                                                    \
+#define _CLLTK_EMIT_META_PTR(_BUFFER_, _META_, _OFFSET_)                                         \
 	__asm__(".pushsection _clltk_" #_BUFFER_ "_metaptr,\"a\"\n\t"                                \
-			".balign " _CLLTK_STR(__SIZEOF_POINTER__) "\n\t"                                     \
-													  ".dc.a " _CLLTK_ASM_SYM_OPERAND "\n\t"     \
+			".balign " _CLLTK_STR(                                                               \
+				__SIZEOF_POINTER__) "\n\t"                                                       \
+									".dc.a " _CLLTK_ASM_SYM_OPERAND(                             \
+										"0") "\n\t"                                              \
+											 ".dc.a " _CLLTK_ASM_SYM_OPERAND(                    \
+												 "1") "\n\t"                                     \
 													  ".popsection" ::_CLLTK_ASM_SYM_CONSTRAINT( \
-														  &_VAR_))
+														  &_META_),                              \
+			_CLLTK_ASM_SYM_CONSTRAINT(&_OFFSET_))
 
 #define _CLLTK_STATIC_TRACEPOINT(_BUFFER_, _FORMAT_, ...)                                         \
 	do {                                                                                          \
@@ -136,10 +159,11 @@ _CLLTK_EXTERN_C_END
 							 "only supporting up to 10 arguments");                               \
 		_CLLTK_CHECK_FOR_ARGUMENTS(__VA_ARGS__);                                                  \
                                                                                                   \
-		/* create meta data for this tracepoint */                                                \
-		/* and emit its address into the discovery section */                                     \
+		/* create meta data for this tracepoint, the per-call-site offset      */                 \
+		/* cache (filled by the startup registration), and a discovery entry  */                  \
+		static _clltk_file_offset_t _clltk_offset = _clltk_file_offset_unset;                     \
 		_CLLTK_CREATE_META_ENTRY_ARGS(_meta, _CLLTK_PLACE_IN(_BUFFER_), _FORMAT_, __VA_ARGS__);   \
-		_CLLTK_EMIT_META_PTR(_BUFFER_, _meta);                                                    \
+		_CLLTK_EMIT_META_PTR(_BUFFER_, _meta, _clltk_offset);                                     \
                                                                                                   \
 		/* create type information for va_list access at runtime. */                              \
 		/* it is not possible to use meta data because there is no */                             \
@@ -156,7 +180,8 @@ _CLLTK_EXTERN_C_END
 			}                                                                                     \
 		}                                                                                         \
                                                                                                   \
-		static _clltk_file_offset_t _clltk_offset = _clltk_file_offset_unset;                     \
+		/* normally already set by the constructor; fallback for call sites   */                  \
+		/* executed before startup registration (constructor priority <= 101) */                  \
 		if (_clltk_offset == _clltk_file_offset_unset) {                                          \
 			_clltk_offset = _clltk_tracebuffer_get_in_file_offset(_tb, &_meta, sizeof(_meta));    \
 		}                                                                                         \
@@ -170,10 +195,11 @@ _CLLTK_EXTERN_C_END
 	do {                                                                                          \
 		/* ------- compile time stuff ------- */                                                  \
                                                                                                   \
-		/* create meta data for this tracepoint */                                                \
-		/* and emit its address into the discovery section */                                     \
+		/* create meta data for this tracepoint, the per-call-site offset      */                 \
+		/* cache (filled by the startup registration), and a discovery entry  */                  \
+		static _clltk_file_offset_t _clltk_offset = _clltk_file_offset_unset;                     \
 		_CLLTK_CREATE_META_ENTRY_DUMP(_meta, _CLLTK_PLACE_IN(_BUFFER_), _MESSAGE_);               \
-		_CLLTK_EMIT_META_PTR(_BUFFER_, _meta);                                                    \
+		_CLLTK_EMIT_META_PTR(_BUFFER_, _meta, _clltk_offset);                                     \
                                                                                                   \
 		static _clltk_tracebuffer_handler_t *const _tb = &_clltk_##_BUFFER_;                      \
                                                                                                   \
@@ -185,7 +211,8 @@ _CLLTK_EXTERN_C_END
 			}                                                                                     \
 		}                                                                                         \
                                                                                                   \
-		static _clltk_file_offset_t _clltk_offset = _clltk_file_offset_unset;                     \
+		/* normally already set by the constructor; fallback for call sites   */                  \
+		/* executed before startup registration (constructor priority <= 101) */                  \
 		if (_clltk_offset == _clltk_file_offset_unset) {                                          \
 			_clltk_offset = _clltk_tracebuffer_get_in_file_offset(_tb, &_meta, sizeof(_meta));    \
 		}                                                                                         \

--- a/tracing_library/source/tracebuffer.c
+++ b/tracing_library/source/tracebuffer.c
@@ -221,6 +221,59 @@ _clltk_file_offset_t _clltk_tracebuffer_get_in_file_offset(_clltk_tracebuffer_ha
 	return _clltk_tracebuffer_add_to_stack(buffer, this_meta, this_meta_size);
 }
 
+void _clltk_tracebuffer_register_metaptrs(_clltk_tracebuffer_handler_t *handler,
+										  const void *const *pairs_start,
+										  const void *const *pairs_stop)
+{
+	if (handler->runtime.tracebuffer == NULL)
+		return; // caller must have initialized the tracebuffer
+
+	if (pairs_stop <= pairs_start)
+		return;
+	const size_t pair_count = (size_t)(pairs_stop - pairs_start) / 2;
+	if (pair_count == 0)
+		return;
+
+	unique_stack_batch_item_t *const items = memory_heap_allocation(pair_count * sizeof(*items));
+	_clltk_file_offset_t **const caches = memory_heap_allocation(pair_count * sizeof(*caches));
+
+	size_t todo = 0;
+	for (size_t i = 0; i < pair_count; i++) {
+		const _clltk_meta_entry_head_t *const head =
+			(const _clltk_meta_entry_head_t *)pairs_start[2 * i];
+		_clltk_file_offset_t *const offset_cache =
+			(_clltk_file_offset_t *)(uintptr_t)pairs_start[2 * i + 1];
+		if (*offset_cache != _clltk_file_offset_unset) {
+			// already resolved, e.g. by another translation unit's
+			// constructor walking the same merged section
+			continue;
+		}
+		items[todo].body = head;
+		items[todo].size = head->size;
+		items[todo].out_offset = 0;
+		caches[todo] = offset_cache;
+		todo++;
+	}
+
+	if (todo > 0) {
+		_clltk_tracebuffer_t *const buffer = handler->runtime.tracebuffer;
+		SYNC_MEMORY_LOCK(lock, buffer->stack_mutex);
+		if (lock.locked == false) {
+			ERROR_LOG("could not lock stack update. ERROR was: %s", lock.error_msg);
+		} else {
+			unique_stack_add_batch(&buffer->stack, items, todo);
+			for (size_t i = 0; i < todo; i++) {
+				// leave the cache unset on failure so the lazy path retries
+				if (_CLLTK_FILE_OFFSET_IS_STATIC(items[i].out_offset))
+					*caches[i] = items[i].out_offset;
+			}
+		}
+	}
+
+	memory_heap_free(caches);
+	memory_heap_free(items);
+}
+
 bool _clltk_tracebuffer_init(_clltk_tracebuffer_handler_t *buffer)
 {
 	SYNC_GLOBAL_LOCK(global_lock);

--- a/tracing_library/source/tracebuffer.c
+++ b/tracing_library/source/tracebuffer.c
@@ -293,8 +293,12 @@ bool _clltk_tracebuffer_init(_clltk_tracebuffer_handler_t *buffer)
 			ERROR_LOG("could not open tracebuffer");
 			return false;
 		}
+		// count attachments, not init calls: every translation unit's
+		// constructor walks the merged discovery section, so init runs
+		// repeatedly per handler, while deinit detaches (and decrements)
+		// exactly once per handler
+		buffer->runtime.tracebuffer->used++;
 	}
-	buffer->runtime.tracebuffer->used++;
 	return true;
 }
 

--- a/tracing_library/source/tracebuffer.c
+++ b/tracing_library/source/tracebuffer.c
@@ -214,25 +214,10 @@ _clltk_file_offset_t _clltk_tracebuffer_get_in_file_offset(_clltk_tracebuffer_ha
 														   const void *const this_meta,
 														   const uint32_t this_meta_size)
 {
-	const uintptr_t elf_sec_start = (uintptr_t)buffer->meta.start;
-	const uintptr_t elf_sec_stop = (uintptr_t)buffer->meta.stop;
-	const uint32_t elf_sec_size = (uint32_t)(elf_sec_stop - elf_sec_start);
-	const uintptr_t this_start = (uintptr_t)this_meta;
-	const uintptr_t this_stop = (uintptr_t)this_meta + (uintptr_t)this_meta_size;
-
-	if ((buffer->runtime.file_offset == _clltk_file_offset_unset) && (elf_sec_size > 0))
-		buffer->runtime.file_offset =
-			_clltk_tracebuffer_add_to_stack(buffer, (const void *)elf_sec_start, elf_sec_size);
-
-	if (buffer->runtime.file_offset == _clltk_file_offset_invalid)
-		return _clltk_file_offset_invalid;
-
-	if ((elf_sec_start <= this_start) && (this_stop <= elf_sec_stop)) {
-		// if meta for this tracepoint is in section
-		return buffer->runtime.file_offset + (_clltk_file_offset_t)(this_start - elf_sec_start);
-	}
-	// if meta for this tracepoint is not in section
-	// this will happen with template functions
+	// meta entries live outside the discovery section (which holds only
+	// pointers to them). Every entry is added individually; the unique stack
+	// deduplicates by content, so an entry already registered by the
+	// constructor walk returns its existing offset.
 	return _clltk_tracebuffer_add_to_stack(buffer, this_meta, this_meta_size);
 }
 

--- a/tracing_library/source/tracebuffer.c
+++ b/tracing_library/source/tracebuffer.c
@@ -304,16 +304,22 @@ void _clltk_tracebuffer_deinit(_clltk_tracebuffer_handler_t *buffer)
 	if (unlikely(buffer->runtime.tracebuffer == NULL))
 		return;
 
-	buffer->runtime.tracebuffer->used--;
-	if (buffer->runtime.tracebuffer->used > 0)
+	// always detach this handler. Handlers deinitialized while other handlers
+	// still hold the tracebuffer must not keep the pointer: it would dangle
+	// once the last handler frees the tracebuffer, and a tracepoint firing
+	// through it afterwards (late destructors, atexit) would use freed
+	// memory instead of hitting the NULL gate.
+	_clltk_tracebuffer_t *const tb = buffer->runtime.tracebuffer;
+	buffer->runtime.tracebuffer = NULL;
+	buffer->runtime.file_offset = 0;
+
+	tb->used--;
+	if (tb->used > 0)
 		return;
 
 	const vector_entry_match_t match =
 		vector_find(tracebufferes, tracebuffer_handler_matcher, buffer->definition.name);
 
-	_clltk_tracebuffer_t *const tb = buffer->runtime.tracebuffer;
-	buffer->runtime.tracebuffer = NULL;
-	buffer->runtime.file_offset = 0;
 	memory_heap_free(tb->name);
 	tb->used = 0;
 	tb->ringbuffer = NULL;
@@ -327,7 +333,6 @@ void _clltk_tracebuffer_deinit(_clltk_tracebuffer_handler_t *buffer)
 
 	if (match.found)
 		vector_remove(tracebufferes, match.position);
-	buffer->runtime.tracebuffer = NULL;
 
 	if (vector_size(tracebufferes) == 0) {
 		vector_free(&tracebufferes);

--- a/tracing_library/source/unique_stack/unique_stack.c
+++ b/tracing_library/source/unique_stack/unique_stack.c
@@ -215,25 +215,37 @@ void unique_stack_add_batch(unique_stack_handler_t *handler, unique_stack_batch_
 		}
 	}
 
-	// append everything that is still unmatched; commit the new body size once
-	// at the end so a crash mid-batch leaves the previous consistent state
-	uint64_t stack_body_size = header.body_size;
+	// append everything that is still unmatched. All new entries are staged
+	// in one buffer and written with a single call instead of two writes per
+	// entry. The new body size is committed once at the end, so a crash
+	// mid-batch leaves the previous consistent state.
+	uint64_t append_size = 0;
 	for (size_t i = 0; i < count; i++) {
 		if (rep[i] != i || items[i].out_offset != 0)
 			continue;
-		entry_head_t entry_head = {
-			.md5_hash = hash_function(items[i].body, items[i].size),
-			.body_size = items[i].size,
-		};
-		entry_head.crc = crc8_continue(0, (const uint8_t *)&entry_head, sizeof(entry_head) - 1);
-		const uint64_t entry_head_offset = body_offset(handler) + stack_body_size;
-		const uint64_t entry_body_offset = entry_head_offset + sizeof(entry_head);
-		file_pwrite(handler->file, items[i].body, items[i].size, entry_body_offset);
-		file_pwrite(handler->file, &entry_head, sizeof(entry_head), entry_head_offset);
-		items[i].out_offset = entry_body_offset;
-		stack_body_size += sizeof(entry_head) + items[i].size;
+		append_size += sizeof(entry_head_t) + items[i].size;
 	}
-	if (stack_body_size != header.body_size) {
+	if (append_size > 0) {
+		uint8_t *const staging = memory_heap_allocation(append_size);
+		uint64_t staged = 0;
+		for (size_t i = 0; i < count; i++) {
+			if (rep[i] != i || items[i].out_offset != 0)
+				continue;
+			entry_head_t entry_head = {
+				.md5_hash = hash_function(items[i].body, items[i].size),
+				.body_size = items[i].size,
+			};
+			entry_head.crc = crc8_continue(0, (const uint8_t *)&entry_head, sizeof(entry_head) - 1);
+			memcpy(staging + staged, &entry_head, sizeof(entry_head));
+			memcpy(staging + staged + sizeof(entry_head), items[i].body, items[i].size);
+			items[i].out_offset =
+				body_offset(handler) + header.body_size + staged + sizeof(entry_head);
+			staged += sizeof(entry_head) + items[i].size;
+		}
+		file_pwrite(handler->file, staging, append_size, body_offset(handler) + header.body_size);
+		memory_heap_free(staging);
+
+		const uint64_t stack_body_size = header.body_size + append_size;
 		const uint64_t stack_body_size_offset =
 			handler->file_offset + offsetof(unique_stack_header_t, body_size);
 		file_pwrite(handler->file, &stack_body_size, sizeof(stack_body_size),

--- a/tracing_library/source/unique_stack/unique_stack.c
+++ b/tracing_library/source/unique_stack/unique_stack.c
@@ -3,6 +3,7 @@
 
 #include "unique_stack.h"
 
+#include "abstraction/memory.h"
 #include "crc8/crc8.h"
 #include "md5/md5.h"
 
@@ -130,4 +131,124 @@ uint64_t unique_stack_add(unique_stack_handler_t *handler, const void *body, uin
 	file_pwrite(handler->file, &stack_body_size, sizeof(stack_body_size), stack_body_size_offset);
 	// return offset of data in file
 	return base_offset + sizeof(entry_head);
+}
+
+// FNV-1a over size then body. Only used for in-memory indexing during batch
+// adds; equality is always confirmed by byte comparison, so collisions are
+// harmless. The md5 in the entry head is untouched (file format unchanged).
+static uint64_t batch_index_hash(const void *body, uint32_t size)
+{
+	uint64_t hash = 0xcbf29ce484222325ull;
+	const uint8_t *bytes = (const uint8_t *)&size;
+	for (size_t i = 0; i < sizeof(size); i++)
+		hash = (hash ^ bytes[i]) * 0x100000001b3ull;
+	bytes = (const uint8_t *)body;
+	for (size_t i = 0; i < size; i++)
+		hash = (hash ^ bytes[i]) * 0x100000001b3ull;
+	return hash;
+}
+
+void unique_stack_add_batch(unique_stack_handler_t *handler, unique_stack_batch_item_t *items,
+							size_t count)
+{
+	RETURN_IF_INVALID(handler);
+	if (items == NULL || count == 0)
+		return;
+
+	// open-addressing index over the batch items (index + 1, 0 = empty slot),
+	// sized to stay at most half full
+	size_t table_size = 2;
+	while (table_size < 2 * count)
+		table_size *= 2;
+	const size_t table_mask = table_size - 1;
+	size_t *table = memory_heap_allocation(table_size * sizeof(*table));
+	memset(table, 0, table_size * sizeof(*table));
+	uint64_t *hashes = memory_heap_allocation(count * sizeof(*hashes));
+	// representative item for items with identical content within the batch
+	size_t *rep = memory_heap_allocation(count * sizeof(*rep));
+
+	for (size_t i = 0; i < count; i++) {
+		items[i].out_offset = 0;
+		hashes[i] = batch_index_hash(items[i].body, items[i].size);
+		rep[i] = i;
+		size_t slot = hashes[i] & table_mask;
+		while (table[slot] != 0) {
+			const size_t other = table[slot] - 1;
+			if (hashes[other] == hashes[i] && items[other].size == items[i].size &&
+				memcmp(items[other].body, items[i].body, items[i].size) == 0) {
+				rep[i] = other;
+				break;
+			}
+			slot = (slot + 1) & table_mask;
+		}
+		if (rep[i] == i)
+			table[slot] = i + 1;
+	}
+
+	// read the existing stack body once and match it against the batch
+	unique_stack_header_t header = {0};
+	file_pread(handler->file, &header, sizeof(header), handler->file_offset);
+	uint8_t *existing = NULL;
+	if (header.body_size > 0) {
+		existing = memory_heap_allocation(header.body_size);
+		file_pread(handler->file, existing, header.body_size, body_offset(handler));
+		uint64_t offset_in_body = 0;
+		while (offset_in_body + sizeof(entry_head_t) <= header.body_size) {
+			const entry_head_t *const head = (const entry_head_t *)(existing + offset_in_body);
+			const uint64_t entry_body_in_body = offset_in_body + sizeof(entry_head_t);
+			if (entry_body_in_body + head->body_size > header.body_size)
+				break; // truncated/corrupt tail, treat rest as absent
+			const uint8_t *const entry_body = existing + entry_body_in_body;
+			const uint64_t entry_hash = batch_index_hash(entry_body, head->body_size);
+			size_t slot = entry_hash & table_mask;
+			while (table[slot] != 0) {
+				const size_t item = table[slot] - 1;
+				if (hashes[item] == entry_hash && items[item].size == head->body_size &&
+					items[item].out_offset == 0 &&
+					memcmp(items[item].body, entry_body, head->body_size) == 0) {
+					items[item].out_offset = body_offset(handler) + entry_body_in_body;
+					break;
+				}
+				slot = (slot + 1) & table_mask;
+			}
+			offset_in_body = entry_body_in_body + head->body_size;
+		}
+	}
+
+	// append everything that is still unmatched; commit the new body size once
+	// at the end so a crash mid-batch leaves the previous consistent state
+	uint64_t stack_body_size = header.body_size;
+	for (size_t i = 0; i < count; i++) {
+		if (rep[i] != i || items[i].out_offset != 0)
+			continue;
+		entry_head_t entry_head = {
+			.md5_hash = hash_function(items[i].body, items[i].size),
+			.body_size = items[i].size,
+		};
+		entry_head.crc = crc8_continue(0, (const uint8_t *)&entry_head, sizeof(entry_head) - 1);
+		const uint64_t entry_head_offset = body_offset(handler) + stack_body_size;
+		const uint64_t entry_body_offset = entry_head_offset + sizeof(entry_head);
+		file_pwrite(handler->file, items[i].body, items[i].size, entry_body_offset);
+		file_pwrite(handler->file, &entry_head, sizeof(entry_head), entry_head_offset);
+		items[i].out_offset = entry_body_offset;
+		stack_body_size += sizeof(entry_head) + items[i].size;
+	}
+	if (stack_body_size != header.body_size) {
+		const uint64_t stack_body_size_offset =
+			handler->file_offset + offsetof(unique_stack_header_t, body_size);
+		file_pwrite(handler->file, &stack_body_size, sizeof(stack_body_size),
+					stack_body_size_offset);
+	}
+
+	// resolve items that were duplicates within the batch
+	for (size_t i = 0; i < count; i++) {
+		if (rep[i] != i)
+			items[i].out_offset = items[rep[i]].out_offset;
+	}
+
+	if (existing != NULL)
+		memory_heap_free(existing);
+	memory_heap_free(rep);
+	memory_heap_free(hashes);
+	memory_heap_free(table);
 }

--- a/tracing_library/source/unique_stack/unique_stack.h
+++ b/tracing_library/source/unique_stack/unique_stack.h
@@ -68,6 +68,26 @@ bool unique_stack_valid(const unique_stack_handler_t *handler);
 // add data to stack and return offset in file for data
 uint64_t unique_stack_add(unique_stack_handler_t *handler, const void *body, uint32_t size);
 
+// one batch item; out_offset receives the file offset of the entry body
+// (0 if the batch failed)
+struct unique_stack_batch_item_t;
+typedef struct unique_stack_batch_item_t unique_stack_batch_item_t;
+struct unique_stack_batch_item_t {
+	const void *body;
+	uint32_t size;
+	uint64_t out_offset;
+};
+
+/**
+ * add many entries at once. Reads the existing stack body once, matches items
+ * against it (and against each other) with a fast hash plus byte comparison,
+ * and appends only entries that are really new. The md5 entry head is only
+ * computed for appended entries. Equivalent to calling unique_stack_add per
+ * item, but O(existing + items) instead of O(existing * items).
+ */
+void unique_stack_add_batch(unique_stack_handler_t *handler, unique_stack_batch_item_t *items,
+							size_t count);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Stack 1/7 — subsequent PRs are based on this branch.

GCC 15.2 rejects mixing COMDAT-grouped and ungrouped ELF sections of the same name in one translation unit, which breaks any TU combining tracepoints in inline/template functions with tracepoints at file scope. LTO masks the error, so CI never saw it.

- Meta discovery switches from placing meta objects in a custom section to emitting `{meta, offset-cache}` pointer pairs into the section via asm (`.pushsection`/`.dc.a`), which is COMDAT-immune. Per-arch operand constraints validated under `-fPIC -Werror` on x86_64, aarch64, and s390x.
- Startup registration batches all meta entries per tracebuffer and pre-resolves file offsets into the call-site caches, so metadata is in the trace file before the first tracepoint fires and the hot path never registers.
- CI gains a non-LTO build leg plus a regression test reproducing the conflict.
- Assorted fixes that surfaced along the way: handler detach on every deinit, python decoder minor-version gate, `.o` relocation support in the ELF reader, single-write batched stack appends, container script quoting, weekly uncached container rebuild, RPM test cache invalidation.

Verified in the CI container: full ctest suite and python suite green, with and without LTO. Version 1.3.0 (registration behavior and ELF discovery layout change).
