### PR TITLE
docs: README accuracy + visible UBSan leg + in-class-tracing regression test (1.7.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,8 +280,11 @@ jobs:
 
   # ============================================
   # Sanitizers - runtime verification of the semantics static lint can't see
-  # (byte packing, endianness, 48-bit offsets, shared-memory sync).
-  #   asan = AddressSanitizer + UBSan   tsan = ThreadSanitizer
+  # (byte packing, endianness, 48-bit offsets, shared-memory sync). Each runs
+  # as its own leg so a finding is unambiguous:
+  #   asan  = AddressSanitizer (+ LeakSanitizer)
+  #   ubsan = UndefinedBehaviorSanitizer
+  #   tsan  = ThreadSanitizer
   # ============================================
   sanitizers:
     runs-on: ubuntu-latest
@@ -295,7 +298,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind: [asan, tsan]
+        kind: [asan, ubsan, tsan]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,9 +38,16 @@
         {
             "name": "unittests-asan",
             "inherits": "unittests-nolto",
-            "description": "ASan + UBSan, no LTO",
+            "description": "AddressSanitizer (+ LeakSanitizer), no LTO",
             "cacheVariables": {
-                "ENABLE_ASAN": "ON",
+                "ENABLE_ASAN": "ON"
+            }
+        },
+        {
+            "name": "unittests-ubsan",
+            "inherits": "unittests-nolto",
+            "description": "UndefinedBehaviorSanitizer, no LTO",
+            "cacheVariables": {
                 "ENABLE_UBSAN": "ON"
             }
         },
@@ -102,6 +109,10 @@
             "configurePreset": "unittests-asan"
         },
         {
+            "name": "unittests-ubsan",
+            "configurePreset": "unittests-ubsan"
+        },
+        {
             "name": "unittests-tsan",
             "configurePreset": "unittests-tsan"
         },
@@ -148,6 +159,16 @@
         {
             "name": "unittests-tsan",
             "configurePreset": "unittests-tsan",
+            "output": {
+                "outputOnFailure": true
+            },
+            "execution": {
+                "noTestsAction": "error"
+            }
+        },
+        {
+            "name": "unittests-ubsan",
+            "configurePreset": "unittests-ubsan",
             "output": {
                 "outputOnFailure": true
             },

--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ See `examples/spans_c` and `examples/spans_cpp`.
       `decoder_tool/python/clltk_decoder.py <path to tracebuffers>`
     - copy tracebuffer with `cp` or create a archive to create a snapshot. And decode it later with:
       `decoder_tool/python/clltk_decoder.py <path to tracebuffers>`
-8. View your traces in `output.csv`
+8. Read the decoded traces. By default they are written to `output.txt`; pass
+   `-o <file>` to choose the destination, and a `.csv` extension to get CSV
+   instead of the aligned text format.
+
+Trace files are decoded on the machine you run the decoder on, regardless of
+the endianness they were written with: a little-endian host can decode a
+big-endian (for example s390x) trace file, and vice versa. This is an offline
+capability - the writer always uses the host's native byte order.
 
 ### Visual timelines
 
@@ -135,34 +142,9 @@ Due to the implementation, design decisions and compiler limitation there are so
   ``` 
 
 
-- **It's not possible** to tracing inside a member function defined inside a class or struct definition, like the following:
-
-  ```c++
-  // header
-  struct A
-  {
-    void foo(void)
-    {
-      CLLTK_TRACEPOINT(My_TB, "it is not possible to trace here"); // fill fail at link-time
-    }
-  }
-  ```
-
-  To still be able to trace in change this to:
-
-  ```c++
-  // header
-  struct A
-  {
-    void foo(void);
-  }
-
-  // source
-  void A::foo(void)
-  {
-    CLLTK_TRACEPOINT(My_TB, "now it is possible to trace here");
-  }
-  ```
+Tracing inside inline functions, function templates, and member functions
+defined inside a class or struct body works as well; the tracepoint meta data
+is discovered in a COMDAT-safe way.
 
 ## Build, Test and Packaging
 
@@ -205,16 +187,23 @@ The CI pipeline is designed so that everything running on GitHub Actions can als
 
 # Or run individual steps:
 ./scripts/container.sh ./scripts/ci-cd/step_format.sh       # Format check
-./scripts/container.sh ./scripts/ci-cd/step_build.sh        # Build
+./scripts/container.sh ./scripts/ci-cd/step_build.sh        # Build (also: --preset unittests-nolto for the consumer-like non-LTO build)
 ./scripts/container.sh ./scripts/ci-cd/step_test.sh         # Tests
 ./scripts/container.sh ./scripts/ci-cd/step_memcheck.sh     # Valgrind memory check
+./scripts/container.sh ./scripts/ci-cd/step_sanitizers.sh asan   # AddressSanitizer + LeakSanitizer
+./scripts/container.sh ./scripts/ci-cd/step_sanitizers.sh ubsan  # UndefinedBehaviorSanitizer
+./scripts/container.sh ./scripts/ci-cd/step_sanitizers.sh tsan   # ThreadSanitizer
+./scripts/container.sh ./scripts/ci-cd/step_build_kernel_module.sh  # Kernel module build + link check
 ./scripts/container.sh ./scripts/ci-cd/step_static_analysis.sh --all  # Static analysis
 ./scripts/container.sh ./scripts/ci-cd/step_package.sh      # RPM packaging
 ```
 
 ### Static Analysis
 
-Static analysis tools (clang-tidy, cppcheck) are integrated into the CI pipeline:
+Static analysis tools (clang-tidy, cppcheck) are integrated into the CI
+pipeline. In CI, clang-tidy runs only on the lines changed by a pull request
+(`--diff <base>`), while cppcheck runs on the whole tree; locally you can run
+either against everything:
 
 ```bash
 # Run all static analysis
@@ -254,7 +243,7 @@ By default all Features, Extensions and debugging tools are build. A minimal bui
 ```
 mkdir build
 cd build
-cmake .. -DCLLTK_SNAPSHOT=OFF -DCLLTK_DECODER=OFF -DCLLTK_COMMAND_LINE_TOOL=OFF -DCLLTK_KERNEL_TRACING=OFF -DCLLTK_EXAMPLES=OFF -DCLLTK_TESTS=OFF
+cmake .. -DCLLTK_SNAPSHOT=OFF -DCLLTK_PYTHON_DECODER=OFF -DCLLTK_CPP_DECODER=OFF -DCLLTK_COMMAND_LINE_TOOL=OFF -DCLLTK_KERNEL_TRACING=OFF -DCLLTK_EXAMPLES=OFF -DCLLTK_TESTS=OFF
 ```
 
 > [!IMPORTANT] Be aware that this disables the build of snapshot and decoding tool. Mixing versions and using this tools from older build is highly discouraged!

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,16 @@
-1.7.2
+1.7.3
 
 # Change log
+## 1.7.3
+- docs: README fixes and additions - remove the (now lifted) in-class-member-function
+  tracing limitation, correct the minimal-build feature flags and the decoder output
+  description, and document the sanitizer, kernel-module and non-LTO CI steps, the
+  clang-tidy diff mode, and offline cross-endian decoding.
+- ci: UndefinedBehaviorSanitizer runs as its own leg (split out of the AddressSanitizer
+  leg) so its findings are unambiguous.
+- test: regression test that a tracepoint inside an in-class member function builds and
+  links.
+
 ## 1.7.2
 - fix: data race on a tracepoint's shared static argument-type info. The one-time
   lazy initialization (`first_time_check`) is now serialized under the global lock and

--- a/scripts/ci-cd/step_sanitizers.sh
+++ b/scripts/ci-cd/step_sanitizers.sh
@@ -14,8 +14,9 @@ cd "${ROOT_PATH}"
 KIND="${1:-asan}"
 case "$KIND" in
     asan) PRESET="unittests-asan" ;;
+    ubsan) PRESET="unittests-ubsan" ;;
     tsan) PRESET="unittests-tsan" ;;
-    *) echo "usage: $0 <asan|tsan>"; exit 1 ;;
+    *) echo "usage: $0 <asan|ubsan|tsan>"; exit 1 ;;
 esac
 
 echo "========================================"

--- a/tests/test_valid_build.py
+++ b/tests/test_valid_build.py
@@ -128,6 +128,24 @@ class valid_build_tests(unittest.TestCase):
                     return 0;
                 }
                 """,
+            # A member function *defined inside* a class body is implicitly
+            # inline, hence COMDAT. This used to fail to link (see the README
+            # "Constrains" section); the COMDAT-safe discovery keeps it working.
+            "in-class member function": """
+                struct A
+                {
+                    void foo(void)
+                    {
+                        CLLTK_TRACEPOINT(BUFFER, "comdat %d", 1);
+                    }
+                };
+                int main(void)
+                {
+                    A{}.foo();
+                    plain_function();
+                    return 0;
+                }
+                """,
         }
         for case_name, comdat_part in comdat_cases.items():
             with self.subTest(case=case_name):


### PR DESCRIPTION
Follow-up (1.7.3): README accuracy + a more visible sanitizer setup, plus a regression test.

**README**
- Remove the "cannot trace inside a member function defined inside a class/struct" limitation — the GCC 15 COMDAT-safe discovery lifted it (verified: two TUs, non-LTO, links and traces).
- Fix the minimal-build command: `-DCLLTK_DECODER=OFF` is not a real option; the actual flags are `-DCLLTK_PYTHON_DECODER=OFF -DCLLTK_CPP_DECODER=OFF`.
- Describe the decoder output accurately — `output.txt` by default, `.csv` optional — instead of a fixed `output.csv`.
- Document the sanitizer, kernel-module and non-LTO CI steps, the clang-tidy diff mode, and offline cross-endian decoding.

**CI**
- UndefinedBehaviorSanitizer runs as its own leg now (split out of the ASan leg) so a UB finding is unambiguous. asan is ASan (+ LeakSanitizer), ubsan is UBSan, tsan is TSan — three isolated legs.

**Test**
- The COMDAT regression test gains an "in-class member function" case so the lifted limitation stays fixed.

Verified in the container: the new UBSan leg builds and runs clean, and the in-class regression case passes.
