### PR TITLE
Remove redundant version header pre-generation in kernel test

### DIFF
--- a/scripts/ci-cd/test_kernelspace.sh
+++ b/scripts/ci-cd/test_kernelspace.sh
@@ -4,7 +4,9 @@
 
 PERSITENT_ARTIFACTS="${PERSITENT_ARTIFACTS:-"./build_kernel/persistent"}"
 
-./cmake/gen_version_header.sh
+# Note: version.gen.h is generated inside build_kernelspace.sh (build_modules ->
+# generate_version_header) and by the kernel Makefile, both with explicit -t/-o
+# arguments. No standalone pre-generation call is needed here.
 ./scripts/ci-cd/build_kernelspace.sh \
     -t "$PERSITENT_ARTIFACTS" \
     -k 5.10.52 \


### PR DESCRIPTION
## What

Removes the standalone `./cmake/gen_version_header.sh` call (no arguments) at the top of `scripts/ci-cd/test_kernelspace.sh`.

## Why

`gen_version_header.sh` requires `-t/-o` (or `-b/-B`); called with no arguments it prints `Error: At least one of -t/-o or -b/-B must be specified` and exits 1. In `test_kernelspace.sh` this was only harmless because the script has no `set -e` — so every kernel-test run dumped a spurious error + help block into the logs while doing nothing useful.

`version.gen.h` is already generated with explicit `-t/-o` arguments in two places that run as part of the build:

- `build_kernelspace.sh` → `build_modules()` → `generate_version_header()` (runs before `make`)
- the kernel `Makefile` `$(VERSION_OUTPUT)` rule (a `make modules` dependency)

The standalone pre-generation call is therefore redundant. Removing it drops the misleading error output without changing behavior.

## Testing

- `bash -n` on both scripts — parse clean.
- Verified the remaining path: running `gen_version_header.sh -t <template> -o <output>` (as `build_kernelspace.sh` does) regenerates `version.gen.h` correctly (`1.7.5`).
- Full QEMU end-to-end could not be run on the dev host (GCC 15 cannot build kernel 5.10.52's `objtool` — a host-toolchain/old-kernel issue unrelated to this change, occurring before the changed code path). Relying on CI for the complete kernel-runtime gate.