### PR TITLE
CI: fix kernel-test version-header call and dnf metadata staleness

### DIFF
--- a/scripts/ci-cd/step_kernel_runtime.sh
+++ b/scripts/ci-cd/step_kernel_runtime.sh
@@ -29,7 +29,24 @@ case "$ARCH" in
     aarch64) QEMU_PKG=qemu-system-aarch64-core ;;
     *) echo "unsupported arch $ARCH"; exit 1 ;;
 esac
-dnf -y install kernel-core kernel-devel kernel-modules-core cpio zstd busybox "$QEMU_PKG" >/dev/null
+# The CI container caches dnf metadata at image build time (refreshed weekly).
+# By mid-week that metadata can still reference a kernel-core NEVRA that Fedora
+# has already superseded and pruned from its mirrors, so a plain install 404s on
+# every mirror. --refresh forces fresh metadata so we resolve to a kernel that
+# still exists; the retry rides out transient mirror interruptions.
+PKGS=(kernel-core kernel-devel kernel-modules-core cpio zstd busybox "$QEMU_PKG")
+for attempt in 1 2 3; do
+    if dnf -y --refresh install "${PKGS[@]}" >/dev/null; then
+        break
+    fi
+    if [ "$attempt" -eq 3 ]; then
+        echo "package install failed after $attempt attempts" >&2
+        exit 1
+    fi
+    echo "dnf install failed (attempt $attempt), clearing cache and retrying..." >&2
+    dnf -y clean expire-cache >/dev/null 2>&1 || true
+    sleep 15
+done
 
 # Pick a version that has both a bootable image and a matching build tree.
 KVER=""

--- a/scripts/ci-cd/test_kernelspace.sh
+++ b/scripts/ci-cd/test_kernelspace.sh
@@ -4,7 +4,9 @@
 
 PERSITENT_ARTIFACTS="${PERSITENT_ARTIFACTS:-"./build_kernel/persistent"}"
 
-./cmake/gen_version_header.sh
+# Note: version.gen.h is generated inside build_kernelspace.sh (build_modules ->
+# generate_version_header) and by the kernel Makefile, both with explicit -t/-o
+# arguments. No standalone pre-generation call is needed here.
 ./scripts/ci-cd/build_kernelspace.sh \
     -t "$PERSITENT_ARTIFACTS" \
     -k 5.10.52 \


### PR DESCRIPTION
Two fixes to the kernel CI path, no functional/library changes.

## 1. Remove redundant version-header pre-generation
`test_kernelspace.sh` called `./cmake/gen_version_header.sh` with no arguments before invoking `build_kernelspace.sh`. That script requires `-t/-o` (or `-b/-B`), so the call always printed `Error: At least one of ...` and exited 1 — harmless only because the script has no `set -e`. `version.gen.h` is already generated with explicit `-t/-o` args by `build_kernelspace.sh` (build_modules → generate_version_header) and by the kernel Makefile's `$(VERSION_OUTPUT)` rule, so the standalone call is redundant. Removing it drops the spurious error from the logs.

## 2. Refresh dnf metadata in the kernel-runtime job
The `kernel-runtime` job installs the stock Fedora kernel inside the CI container, which caches dnf repo metadata at image build time (rebuilt weekly). By mid-week that metadata can reference a `kernel-core` NEVRA Fedora has already pruned from its mirrors → 404 on every mirror (this failed post-merge CI on main). `dnf --refresh` forces fresh metadata so the install resolves to a kernel that still exists, plus a small retry loop for transient mirror interruptions. The existing version-selection logic tolerates whichever kernel gets installed, so no pinning is needed.

## Testing
- `bash -n` clean on both scripts.
- Fix 1's remaining generation path verified locally (produces the correct `version.gen.h`).
- Fix 2 is validated by this PR's own `kernel-runtime` check (touches `scripts/ci-cd/`, so the job runs).