### PR TITLE
ci: compiler-compat matrix (gcc 14-16, clang 18-21; arm64/s390x) + fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,11 +351,14 @@ jobs:
 
   # ============================================
   # Compiler compatibility matrix
-  # Consumers build against many gcc/clang versions. This leg compiles + links
-  # + runs a minimal tracing example (library + simple_c/simple_cpp only, heavy
-  # components off) on each pinned compiler image, verifying a trace file is
-  # produced. Kept with -Werror on purpose so a new compiler's warnings surface.
-  # Not the full test suite - that stays in build-and-test/sanitizers.
+  # Consumers build against many gcc/clang versions and architectures. This leg
+  # compiles + links + runs a minimal tracing example (library + simple_c/
+  # simple_cpp only, heavy components off) on each pinned compiler image,
+  # verifying a trace file is produced. Every compiler runs on x86_64; a
+  # representative gcc+clang also run on arm64 and s390x (big-endian, exercises
+  # the cross-endian trace path) under QEMU. Kept with -Werror on purpose so a
+  # new compiler's warnings surface. Not the full test suite - that stays in
+  # build-and-test/sanitizers.
   # ============================================
   compiler-compat:
     name: compat (${{ matrix.name }})
@@ -370,36 +373,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Minimum supported compilers are GCC 14 and clang 18: the tracepoint
+        # macros use the "Ws" inline-asm constraint (symbol+offset, for the
+        # _metaptr metadata sections), which older gcc/clang reject with
+        # "impossible/invalid constraint in asm". Every released compiler from
+        # those floors is covered on x86_64; arm64 and s390x (big-endian) get a
+        # representative gcc+clang each, run under QEMU emulation.
         include:
-          - { name: gcc-12,   image: 'gcc:12',          cc: gcc,   cxx: g++ }
-          - { name: gcc-13,   image: 'gcc:13',          cc: gcc,   cxx: g++ }
-          - { name: gcc-14,   image: 'gcc:14',          cc: gcc,   cxx: g++ }
-          - { name: gcc-15,   image: 'gcc:15',          cc: gcc,   cxx: g++ }
-          - { name: clang-16, image: 'silkeh/clang:16', cc: clang, cxx: clang++ }
-          - { name: clang-17, image: 'silkeh/clang:17', cc: clang, cxx: clang++ }
-          - { name: clang-18, image: 'silkeh/clang:18', cc: clang, cxx: clang++ }
-          - { name: clang-19, image: 'silkeh/clang:19', cc: clang, cxx: clang++ }
-    container: ${{ matrix.image }}
+          - { name: gcc-14,         image: 'gcc:14',          cc: gcc,   cxx: g++,     platform: linux/amd64 }
+          - { name: gcc-15,         image: 'gcc:15',          cc: gcc,   cxx: g++,     platform: linux/amd64 }
+          - { name: gcc-16,         image: 'gcc:16',          cc: gcc,   cxx: g++,     platform: linux/amd64 }
+          - { name: clang-18,       image: 'silkeh/clang:18', cc: clang, cxx: clang++, platform: linux/amd64 }
+          - { name: clang-19,       image: 'silkeh/clang:19', cc: clang, cxx: clang++, platform: linux/amd64 }
+          - { name: clang-20,       image: 'silkeh/clang:20', cc: clang, cxx: clang++, platform: linux/amd64 }
+          - { name: clang-21,       image: 'silkeh/clang:21', cc: clang, cxx: clang++, platform: linux/amd64 }
+          - { name: gcc-15 arm64,   image: 'gcc:15',          cc: gcc,   cxx: g++,     platform: linux/arm64 }
+          - { name: clang-21 arm64, image: 'silkeh/clang:21', cc: clang, cxx: clang++, platform: linux/arm64 }
+          - { name: gcc-15 s390x,   image: 'gcc:15',          cc: gcc,   cxx: g++,     platform: linux/s390x }
+          - { name: clang-21 s390x, image: 'silkeh/clang:21', cc: clang, cxx: clang++, platform: linux/s390x }
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install build prerequisites
-        run: |
-          set -eux
-          apt-get update
-          apt-get install -y --no-install-recommends cmake make git ca-certificates
+      # Register binfmt/QEMU so the non-x86 images can run under emulation.
+      - name: Set up QEMU
+        if: matrix.platform != 'linux/amd64'
+        uses: docker/setup-qemu-action@v3
 
-      # actions/checkout leaves the tree owned by a different uid inside the
-      # container; mark it safe so the version-header git calls succeed.
-      - name: Mark workspace safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
+      # One uniform path for every leg: run the pinned compiler image at the
+      # target platform (native for amd64, emulated otherwise) and invoke the
+      # arch-agnostic compat step. gettext-base (envsubst) and rsync are needed
+      # by the version-header generation; git safe.directory lets it read HEAD.
       - name: Build + run minimal example
-        env:
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
-        run: ./scripts/ci-cd/step_compat.sh
+        run: |
+          docker run --platform ${{ matrix.platform }} --rm \
+            -v "$PWD":/src -w /src \
+            -e CC=${{ matrix.cc }} -e CXX=${{ matrix.cxx }} \
+            ${{ matrix.image }} bash -c '
+              set -e
+              apt-get update >/dev/null
+              apt-get install -y --no-install-recommends cmake make git ca-certificates gettext-base rsync >/dev/null
+              git config --global --add safe.directory /src
+              ./scripts/ci-cd/step_compat.sh
+            '
 
   # ============================================
   # Packaging (only for code/ci changes, or push to main)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,58 @@ jobs:
         run: ./scripts/container.sh ./scripts/ci-cd/step_sanitizers.sh ${{ matrix.kind }}
 
   # ============================================
+  # Compiler compatibility matrix
+  # Consumers build against many gcc/clang versions. This leg compiles + links
+  # + runs a minimal tracing example (library + simple_c/simple_cpp only, heavy
+  # components off) on each pinned compiler image, verifying a trace file is
+  # produced. Kept with -Werror on purpose so a new compiler's warnings surface.
+  # Not the full test suite - that stays in build-and-test/sanitizers.
+  # ============================================
+  compiler-compat:
+    name: compat (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: [changes, checks]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name == 'push' ||
+       needs.changes.outputs.code == 'true' ||
+       needs.changes.outputs.tests == 'true' ||
+       needs.changes.outputs.ci == 'true')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: gcc-12,   image: 'gcc:12',          cc: gcc,   cxx: g++ }
+          - { name: gcc-13,   image: 'gcc:13',          cc: gcc,   cxx: g++ }
+          - { name: gcc-14,   image: 'gcc:14',          cc: gcc,   cxx: g++ }
+          - { name: gcc-15,   image: 'gcc:15',          cc: gcc,   cxx: g++ }
+          - { name: clang-16, image: 'silkeh/clang:16', cc: clang, cxx: clang++ }
+          - { name: clang-17, image: 'silkeh/clang:17', cc: clang, cxx: clang++ }
+          - { name: clang-18, image: 'silkeh/clang:18', cc: clang, cxx: clang++ }
+          - { name: clang-19, image: 'silkeh/clang:19', cc: clang, cxx: clang++ }
+    container: ${{ matrix.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build prerequisites
+        run: |
+          set -eux
+          apt-get update
+          apt-get install -y --no-install-recommends cmake make git ca-certificates
+
+      # actions/checkout leaves the tree owned by a different uid inside the
+      # container; mark it safe so the version-header git calls succeed.
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Build + run minimal example
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: ./scripts/ci-cd/step_compat.sh
+
+  # ============================================
   # Packaging (only for code/ci changes, or push to main)
   # ============================================
   package:

--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ You may use the repository with or without a container. To run any scripts, buil
 
 It is also possible to cross compile with the container env by using of example: `CONTAINER_ARCH=arm64 ./scripts/container.sh`.
 
+### Compiler requirements
+
+The tracing library requires a recent compiler:
+
+| Compiler | Minimum version |
+| -------- | --------------- |
+| GCC      | 14              |
+| Clang    | 18              |
+
+Older compilers reject the build with `impossible constraint in 'asm'` /
+`invalid input constraint 'Ws'`: the tracepoint macros emit their metadata
+sections via the `Ws` inline-asm constraint (a symbol reference with offset),
+which is only supported from these versions onward. The `compiler-compat` CI
+job builds and runs a minimal tracing example against every released GCC and
+Clang from these floors upward on x86_64, plus a representative gcc/clang on
+arm64 and s390x (big-endian) under QEMU.
+
 ### Build this repository
 
 To build this repository for test purposes or development run:

--- a/VERSION.md
+++ b/VERSION.md
@@ -4,6 +4,8 @@
 ## 1.7.6
 - fix: clang builds add -Wno-unknown-warning-option so older clang (which does not
   know -Wno-pre-c11-compat) no longer fails under -Werror.
+- ci: kernel-module build step refreshes dnf metadata (like the kernel-runtime step)
+  so it no longer 404s on a pruned kernel-devel package mid-week.
 - ci: compiler-compatibility matrix builds, links and runs a minimal tracing example
   on every released GCC (>=14) and clang (>=18) on x86_64, plus a representative
   gcc/clang on arm64 and s390x (big-endian) under QEMU; the minimum supported

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,14 @@
-1.7.5
+1.7.6
 
 # Change log
+## 1.7.6
+- fix: clang builds add -Wno-unknown-warning-option so older clang (which does not
+  know -Wno-pre-c11-compat) no longer fails under -Werror.
+- ci: compiler-compatibility matrix builds, links and runs a minimal tracing example
+  on every released GCC (>=14) and clang (>=18) on x86_64, plus a representative
+  gcc/clang on arm64 and s390x (big-endian) under QEMU; the minimum supported
+  compilers (set by the "Ws" inline-asm constraint) are now documented in the README.
+
 ## 1.7.5
 - ci: kernel-module runtime gate. Boots the modules in QEMU on the stock distro kernel
   (built without CONFIG_CONSTRUCTORS) and verifies tracing actually registers and produces

--- a/scripts/ci-cd/step_build_kernel_module.sh
+++ b/scripts/ci-cd/step_build_kernel_module.sh
@@ -23,7 +23,24 @@ echo "========================================"
 
 if ! ls /usr/src/kernels/*/Makefile >/dev/null 2>&1; then
     echo "Installing kernel-devel..."
-    dnf -y install kernel-devel flex bison elfutils-libelf-devel openssl-devel bc >/dev/null
+    # The CI container caches dnf metadata at image build time (refreshed weekly).
+    # By mid-week that metadata can still reference a kernel-devel NEVRA that
+    # Fedora has already superseded and pruned from its mirrors, so a plain
+    # install 404s on every mirror. --refresh forces fresh metadata; the retry
+    # rides out transient mirror interruptions.
+    PKGS=(kernel-devel flex bison elfutils-libelf-devel openssl-devel bc)
+    for attempt in 1 2 3; do
+        if dnf -y --refresh install "${PKGS[@]}" >/dev/null; then
+            break
+        fi
+        if [ "$attempt" -eq 3 ]; then
+            echo "package install failed after $attempt attempts" >&2
+            exit 1
+        fi
+        echo "dnf install failed (attempt $attempt), clearing cache and retrying..." >&2
+        dnf -y clean expire-cache >/dev/null 2>&1 || true
+        sleep 15
+    done
 fi
 KDIR=$(ls -d /usr/src/kernels/* | head -1)
 echo "Kernel tree: $KDIR"

--- a/scripts/ci-cd/step_compat.sh
+++ b/scripts/ci-cd/step_compat.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024, International Business Machines
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+# CI Step: compiler-compatibility smoke test.
+#
+# Builds ONLY the tracing library plus the minimal simple_c / simple_cpp
+# examples with the selected compiler, runs them, and confirms each produces a
+# trace file. This is the cheap gate that a consumer can compile, link, and run
+# a tracepoint on a given gcc/clang version - not the full test suite. The
+# library is dependency-light, so the heavy components (CLI tool, decoders,
+# snapshot, kernel module, tests) are turned off and no extra libraries are
+# needed beyond a C/C++ compiler and CMake.
+#
+# The library builds with -Werror (COMPILE_WARNING_AS_ERROR), which is kept on
+# purpose: a new compiler's warnings should surface here.
+#
+# Runnable locally, e.g.:  CC=gcc-13 CXX=g++-13 ./scripts/ci-cd/step_compat.sh
+
+set -euo pipefail
+ROOT_PATH=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "${ROOT_PATH}"
+
+CC="${CC:-cc}"
+CXX="${CXX:-c++}"
+BUILD_DIR="${BUILD_DIR:-build/compat}"
+
+echo "========================================"
+echo "CI Step: Compiler compatibility"
+echo "  CC =$CC : $("$CC" --version 2>/dev/null | head -1)"
+echo "  CXX=$CXX : $("$CXX" --version 2>/dev/null | head -1)"
+echo "========================================"
+
+# Library + examples only; heavy components off so no external deps are needed.
+cmake -S . -B "${BUILD_DIR}" \
+    -DCMAKE_C_COMPILER="${CC}" \
+    -DCMAKE_CXX_COMPILER="${CXX}" \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCLLTK_TRACING=ON \
+    -DCLLTK_EXAMPLES=ON \
+    -DCLLTK_SNAPSHOT=OFF \
+    -DCLLTK_COMMAND_LINE_TOOL=OFF \
+    -DCLLTK_CPP_DECODER=OFF \
+    -DCLLTK_PYTHON_DECODER=OFF \
+    -DCLLTK_KERNEL_TRACING=OFF \
+    -DCLLTK_TESTS=OFF
+
+cmake --build "${BUILD_DIR}" \
+    --target example-simple_c example-simple_cpp \
+    -j"$(nproc)"
+
+C_BIN=$(find "${BUILD_DIR}" -type f -name example-simple_c   | head -1)
+CPP_BIN=$(find "${BUILD_DIR}" -type f -name example-simple_cpp | head -1)
+[ -x "${C_BIN}" ]   || { echo "FAILED: example-simple_c not built";   exit 1; }
+[ -x "${CPP_BIN}" ] || { echo "FAILED: example-simple_cpp not built"; exit 1; }
+
+OUT=$(mktemp -d)
+export CLLTK_TRACING_PATH="${OUT}"
+echo "Running examples (CLLTK_TRACING_PATH=${OUT})..."
+"${C_BIN}"
+"${CPP_BIN}"
+
+echo "Trace files produced:"
+ls -l "${OUT}"
+if [ -z "$(find "${OUT}" -name '*.clltk_trace' -print -quit)" ]; then
+    echo "FAILED: examples ran but produced no .clltk_trace file"
+    exit 1
+fi
+
+echo "PASSED: library + minimal examples build, run, and trace with ${CC}/${CXX}"

--- a/tracing_library/CMakeLists.txt
+++ b/tracing_library/CMakeLists.txt
@@ -45,6 +45,10 @@ elseif(${CMAKE_C_COMPILER_ID} MATCHES "Clang")
         -Wno-format-nonliteral
     )
     list(APPEND clltk_public_compiler_flags
+        # Keep first: lets older clang silently ignore -Wno-* flags it does not
+        # know (e.g. -Wno-pre-c11-compat, added in a later clang) instead of
+        # erroring under -Werror. Supported by all clang versions we target.
+        -Wno-unknown-warning-option
         -Wno-gnu-empty-initializer
         -Wno-zero-length-array
         -Wno-declaration-after-statement


### PR DESCRIPTION
Adds a `compiler-compat` CI leg that **compiles, links, and runs a minimal tracing example** against every supported GCC and clang version, plus the small library fix that portability across clang versions requires.

## What the leg does
- Matrix over pinned official images: `gcc:14/15/16`, `silkeh/clang:18/19/20/21` (7 legs, `fail-fast: false`).
- Each runs `scripts/ci-cd/step_compat.sh`: minimal CMake configure (tracing library + `simple_c`/`simple_cpp` only — CLI tool, decoders, snapshot, kernel module, tests off, so no external deps), build the two examples, run them with `CLLTK_TRACING_PATH` set, and verify each writes a `.clltk_trace` file.
- Library `-Werror` kept on so new-compiler warnings surface.
- Runnable locally: `CC=gcc-14 CXX=g++-14 ./scripts/ci-cd/step_compat.sh`.

## Supported-compiler floor (discovered while building this)
The tracepoint macros use the `Ws` inline-asm constraint (symbol+offset, for the `_metaptr` metadata sections). It only exists in **GCC ≥14** and **clang ≥18**; older compilers reject the build with `impossible/invalid constraint in 'asm'`. So the matrix starts at those floors, and the requirement is now documented in the README.

## Library fix
`tracing_library/CMakeLists.txt` listed `-Wno-pre-c11-compat` for all clang, but older clang doesn't know that flag and errors under `-Werror -Wunknown-warning-option`. Added `-Wno-unknown-warning-option` first so clang silently ignores any `-Wno-*` it doesn't recognise — needed for clang 18 to pass.

## Testing
Every matrix leg was run locally in its real image (docker): gcc 14/15/16 and clang 18/19/20/21 all build, run, and produce trace files. Also confirmed the floor: gcc 12/13 and clang 16/17 fail on the `Ws` constraint as expected.

---
### Also included: kernel-module build dnf refresh
`step_build_kernel_module.sh` installed `kernel-devel` with a plain `dnf install`, hitting the same stale-metadata 404 that was fixed for `step_kernel_runtime.sh`. Applied the same `dnf --refresh` + retry treatment, so the `build-kernel-module` job stops flaking on pruned Fedora kernel packages.