### PR TITLE
fix: emit _metaptr section writable to avoid text relocations

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,18 @@
-1.7.6
+1.7.7
 
 # Change log
+## 1.7.7
+- fix: tracepoints compiled into a shared library no longer produce text relocations
+  (DT_TEXTREL). The `_clltk_<buffer>_metaptr` discovery section is now emitted writable, so
+  its absolute pointers become load-time RELATIVE relocations instead of forcing a text
+  relocation; a read-only section broke PIE/hardened targets (e.g. AArch64) at load time and
+  failed packaging QA (do_package_qa). No API or ABI change - recompile against the header.
+- test: a packaging consumer test builds a shared library against the installed headers and
+  asserts the produced .so is free of text relocations and an executable stack.
+- ci: the compiler-compat matrix links a tracepoint-bearing shared object with `-z text` on
+  every compiler and architecture (incl. arm64/s390x) so a text-relocation regression is a
+  hard error; the tracing library and example shared libraries link with `--fatal-warnings`.
+
 ## 1.7.6
 - fix: clang builds add -Wno-unknown-warning-option so older clang (which does not
   know -Wno-pre-c11-compat) no longer fails under -Werror.

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -42,3 +42,17 @@ if(_clltk_sanitizers)
         add_compile_options(-fno-sanitize-recover=undefined)
     endif()
 endif()
+
+# Linker-warning hygiene for our own binaries: promote linker warnings (e.g.
+# "creating DT_TEXTREL") to errors so they cannot hide in an otherwise green
+# build. Consumed via target_link_options by the tracing library and the
+# example shared libraries; kept PRIVATE at each use site so it never reaches
+# consumers. Empty (a no-op) unless linking with the GNU-style driver on Linux,
+# and disabled under sanitizers - the sanitizer runtimes can emit benign linker
+# diagnostics, and the non-sanitizer build/package/compat legs already give full
+# link-warning coverage.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT _clltk_sanitizers)
+    set(CLLTK_FATAL_LINKER_WARNINGS -Wl,--fatal-warnings)
+else()
+    set(CLLTK_FATAL_LINKER_WARNINGS "")
+endif()

--- a/examples/with_libraries/CMakeLists.txt
+++ b/examples/with_libraries/CMakeLists.txt
@@ -39,6 +39,14 @@ target_link_directories(example-with_libraries-static
         .
 )
 
+# These two SHARED libraries expand the tracepoint macros inside a .so - the
+# shape a consumer plugin/driver has. CLLTK_FATAL_LINKER_WARNINGS (from
+# Sanitizers.cmake) fails the build on a "creating DT_TEXTREL" (or any other)
+# linker warning here, instead of letting it scroll past unread; it is empty
+# under sanitizers. The authoritative check is the packaging consumer test
+# tests/packaging/test_consumer_shared_lib.py, which inspects the produced .so
+# against the *installed* headers; this is the cheap build-time tripwire.
+
 # example-with_libraries-shared ###########################
 add_library(example-with_libraries-shared SHARED
     shared.cpp
@@ -48,6 +56,11 @@ target_link_libraries(example-with_libraries-shared
     PRIVATE
         clltk_tracing
         clltk_example_flags
+)
+
+target_link_options(example-with_libraries-shared
+    PRIVATE
+        ${CLLTK_FATAL_LINKER_WARNINGS}
 )
 
 target_link_directories(example-with_libraries-shared
@@ -65,6 +78,11 @@ target_link_libraries(example-with_libraries-dynamic
     PRIVATE
         clltk_tracing
         clltk_example_flags
+)
+
+target_link_options(example-with_libraries-dynamic
+    PRIVATE
+        ${CLLTK_FATAL_LINKER_WARNINGS}
 )
 
 target_link_directories(example-with_libraries-dynamic

--- a/scripts/ci-cd/step_compat.sh
+++ b/scripts/ci-cd/step_compat.sh
@@ -67,4 +67,48 @@ if [ -z "$(find "${OUT}" -name '*.clltk_trace' -print -quit)" ]; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Text-relocation guard for the "tracepoint inside a shared library" shape.
+#
+# A consumer shared object (a plugin/driver .so) expands the tracepoint macros
+# *inside the .so*, which emits the _metaptr metadata section. If that section
+# is ever read-only, its absolute pointers become text relocations
+# (DT_TEXTREL): -fPIC cannot avoid them, hardened targets (AArch64) reject them
+# at load time, and Yocto's do_package_qa fails the build. The main test suite
+# links such a shared library but only ever *warns* on TEXTREL, so the
+# regression stayed invisible. Here we build a minimal tracepoint-bearing
+# shared object with "-z text", which makes the linker refuse to emit any text
+# relocation - a hard error. Because this runs on every compiler and every arch
+# in the matrix (incl. arm64 and s390x under QEMU), it catches both generic and
+# arch-specific reintroductions. A shared object may keep undefined symbols, so
+# no CLLTK runtime needs to be linked - the relocations are a property of the
+# consumer object alone.
+echo "Checking tracepoint-in-shared-library is text-relocation free (-z text)..."
+GUARD_SRC="${OUT}/clltk_textrel_guard.c"
+GUARD_SO="${OUT}/libclltk_textrel_guard.so"
+cat > "${GUARD_SRC}" <<'GUARD_EOF'
+#include "CommonLowLevelTracingKit/tracing/tracing.h"
+CLLTK_TRACEBUFFER(compat_textrel_guard, 4096);
+void clltk_compat_textrel_guard(int x) {
+    CLLTK_TRACEPOINT(compat_textrel_guard, "textrel guard %d", x);
+}
+GUARD_EOF
+if ! "${CC}" -fPIC -shared -O2 -I"${ROOT_PATH}/tracing_library/include" \
+        -Wl,-z,text "${GUARD_SRC}" -o "${GUARD_SO}"; then
+    echo "FAILED: a tracepoint compiled into a shared library produced text"
+    echo "        relocations (DT_TEXTREL). This breaks PIE/hardened targets"
+    echo "        and Yocto do_package_qa. See _CLLTK_EMIT_META_PTR - the"
+    echo "        _metaptr section must be emitted writable (\"aw\")."
+    exit 1
+fi
+# Belt and suspenders: fail if a TEXTREL somehow survived the link (e.g. a
+# linker that only warns). Skipped if readelf is unavailable.
+if command -v readelf >/dev/null 2>&1; then
+    if readelf -dW "${GUARD_SO}" 2>/dev/null | grep -qiE '\bTEXTREL\b'; then
+        echo "FAILED: DT_TEXTREL present in ${GUARD_SO} despite -z text"
+        exit 1
+    fi
+fi
+
 echo "PASSED: library + minimal examples build, run, and trace with ${CC}/${CXX}"
+echo "PASSED: tracepoint-in-shared-library is free of text relocations"

--- a/tests/packaging/consumer_shared_project/CMakeLists.txt
+++ b/tests/packaging/consumer_shared_project/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, International Business Machines
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+cmake_minimum_required(VERSION 3.20)
+project(clltk_consumer_shared_test LANGUAGES C)
+
+find_package(CLLTK REQUIRED)
+
+# A consumer SHARED library that expands the tracepoint macros *inside the .so*.
+# This is the shape - a plugin/driver shared object that traces - whose _metaptr
+# metadata section must be writable; if it regresses to read-only, its absolute
+# pointers become text relocations (DT_TEXTREL). The test harness inspects this
+# .so with readelf and fails on any text relocation, the same check a hardened
+# packaging QA performs. Built as a plain shared library with no special link
+# flags on purpose: it must be clean the way an ordinary consumer builds it,
+# not only when forced with -z text.
+add_library(consumer_plugin SHARED plugin.c)
+target_link_libraries(consumer_plugin PRIVATE clltk::clltk_tracing_shared)
+
+# An application that links the plugin and drives it, proving cross-.so tracing
+# works end to end against the installed package.
+add_executable(app app.c)
+target_link_libraries(app PRIVATE consumer_plugin)

--- a/tests/packaging/consumer_shared_project/app.c
+++ b/tests/packaging/consumer_shared_project/app.c
@@ -1,0 +1,14 @@
+/* Copyright (c) 2024, International Business Machines
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Drives the consumer plugin shared library so cross-.so tracing is exercised
+ * end to end against the installed package.
+ */
+
+extern void plugin_emit(int value);
+
+int main(void)
+{
+	plugin_emit(42);
+	return 0;
+}

--- a/tests/packaging/consumer_shared_project/plugin.c
+++ b/tests/packaging/consumer_shared_project/plugin.c
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024, International Business Machines
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * A consumer shared library that traces. Expanding the tracepoint macros here
+ * emits the _clltk_<buffer>_metaptr section into this .so; that section must be
+ * writable so the dynamic linker relocates its absolute pointers without a text
+ * relocation (DT_TEXTREL). The packaging test loads this .so and asserts it is
+ * text-relocation free.
+ */
+
+#include <CommonLowLevelTracingKit/tracing/tracing.h>
+
+CLLTK_TRACEBUFFER(consumer_plugin_buf, 4096);
+
+void plugin_emit(int value)
+{
+	CLLTK_TRACEPOINT(CLLTK_TRACEBUFFER_MACRO_VALUE(consumer_plugin_buf), "plugin traced value %d",
+					 value);
+}

--- a/tests/packaging/helpers/consumer.py
+++ b/tests/packaging/helpers/consumer.py
@@ -58,6 +58,20 @@ def create_temp_consumer_project(
     return tmpdir
 
 
+def create_temp_project_copy(src_dir: pathlib.Path) -> pathlib.Path:
+    """Copy an entire consumer-project fixture directory to a temp location.
+
+    Unlike create_temp_consumer_project (which copies a single source plus the
+    CMakeLists), this copies the whole fixture tree, for projects with several
+    sources (e.g. a shared library plus a driver executable). The caller cleans
+    up with shutil.rmtree.
+    """
+    tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="clltk_consumer_"))
+    dest = tmpdir / src_dir.name
+    shutil.copytree(src_dir, dest)
+    return dest
+
+
 def configure_cmake_project(
     project_dir: pathlib.Path,
     install_prefix: pathlib.Path,

--- a/tests/packaging/test_consumer_shared_lib.py
+++ b/tests/packaging/test_consumer_shared_lib.py
@@ -1,0 +1,165 @@
+#!/usr/bin/python3
+# Copyright (c) 2024, International Business Machines
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+"""Level 2+: Test CLLTK consumed from a downstream SHARED library.
+
+The regression this guards: a tracepoint compiled *into a shared object* emits
+the _clltk_<buffer>_metaptr metadata section. If that section is read-only, its
+absolute pointers become text relocations (DT_TEXTREL) - which -fPIC cannot
+avoid, which hardened/PIE targets reject at load time, and which a packaging QA
+gate (e.g. Yocto do_package_qa) fails outright.
+
+The other consumer tests build an *executable*, where the linker resolves those
+pointers at link time and no text relocation appears - so they never exercise
+this shape. This test builds a genuine consumer shared library against the
+*installed* package and inspects the produced .so with readelf, exactly as a
+hardened packaging QA would. It is deliberately built with no special link
+flags: the .so must be clean the way an ordinary consumer builds it.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from .helpers.consumer import (
+    build_cmake_project,
+    configure_cmake_project,
+    create_temp_project_copy,
+)
+from .helpers.rpm import (
+    cmake_install_to_prefix,
+    ensure_rpms_built,
+)
+
+FIXTURE_DIR = pathlib.Path(__file__).parent / "consumer_shared_project"
+
+
+def setUpModule():
+    """Ensure RPM packages are built before running any tests."""
+    ensure_rpms_built()
+
+
+def _find_plugin_so(project_dir: pathlib.Path) -> pathlib.Path:
+    """Locate the built consumer plugin shared object."""
+    matches = list((project_dir / "build").rglob("libconsumer_plugin*.so"))
+    return matches[0] if matches else None
+
+
+@unittest.skipUnless(shutil.which("readelf"), "readelf (binutils) not available")
+class TestConsumerSharedLib(unittest.TestCase):
+    """A downstream shared library that traces must be text-relocation free."""
+
+    _prefix = None
+    _project_dir = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls._prefix = pathlib.Path(tempfile.mkdtemp(prefix="clltk_sharedlib_prefix_"))
+        cmake_install_to_prefix(cls._prefix)
+        cls._project_dir = create_temp_project_copy(FIXTURE_DIR)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prefix and cls._prefix.exists():
+            shutil.rmtree(cls._prefix, ignore_errors=True)
+        if cls._project_dir and cls._project_dir.exists():
+            shutil.rmtree(cls._project_dir.parent, ignore_errors=True)
+
+    def _ensure_built(self):
+        cfg = configure_cmake_project(self._project_dir, self._prefix)
+        self.assertTrue(
+            cfg.success,
+            f"CMake configure failed:\nstdout: {cfg.stdout}\nstderr: {cfg.stderr}",
+        )
+        build = build_cmake_project(self._project_dir)
+        self.assertTrue(
+            build.success,
+            f"CMake build failed:\nstdout: {build.stdout}\nstderr: {build.stderr}",
+        )
+
+    def test_01_build(self):
+        """The consumer shared library and its driver must build."""
+        self._ensure_built()
+        so = _find_plugin_so(self._project_dir)
+        self.assertIsNotNone(so, "libconsumer_plugin.so was not produced")
+
+    def test_02_no_text_relocations(self):
+        """The consumer .so must have no DT_TEXTREL (the do_package_qa check)."""
+        self._ensure_built()
+        so = _find_plugin_so(self._project_dir)
+        self.assertIsNotNone(so, "libconsumer_plugin.so was not produced")
+
+        dyn = subprocess.run(
+            ["readelf", "-dW", str(so)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(dyn.returncode, 0, f"readelf -d failed: {dyn.stderr}")
+        offending = [ln for ln in dyn.stdout.splitlines() if "TEXTREL" in ln]
+        self.assertEqual(
+            offending,
+            [],
+            "consumer shared library has text relocations (DT_TEXTREL); a "
+            "tracepoint's _metaptr section regressed to read-only. This breaks "
+            "PIE/hardened targets and packaging QA. Offending readelf lines:\n"
+            + "\n".join(offending),
+        )
+
+    def test_03_no_executable_stack(self):
+        """The consumer .so must not request an executable stack."""
+        self._ensure_built()
+        so = _find_plugin_so(self._project_dir)
+        self.assertIsNotNone(so, "libconsumer_plugin.so was not produced")
+
+        seg = subprocess.run(
+            ["readelf", "-lW", str(so)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(seg.returncode, 0, f"readelf -l failed: {seg.stderr}")
+        for line in seg.stdout.splitlines():
+            if "GNU_STACK" in line:
+                # Flags column: RWE - an 'E' means executable stack.
+                self.assertNotIn(
+                    "RWE",
+                    line,
+                    f"consumer shared library requests an executable stack: {line}",
+                )
+
+    def test_04_run_traces_across_so(self):
+        """Driving the plugin must produce a trace file (cross-.so tracing)."""
+        self._ensure_built()
+        build_dir = self._project_dir / "build"
+        app = build_dir / "app"
+        self.assertTrue(app.exists(), "driver executable 'app' was not built")
+
+        env = os.environ.copy()
+        trace_dir = self._project_dir / "traces"
+        trace_dir.mkdir(exist_ok=True)
+        env["CLLTK_TRACING_PATH"] = str(trace_dir)
+        lib_dirs = [
+            str(build_dir),
+            str(self._prefix / "lib64"),
+            str(self._prefix / "lib"),
+        ]
+        existing = env.get("LD_LIBRARY_PATH", "")
+        env["LD_LIBRARY_PATH"] = ":".join(lib_dirs + ([existing] if existing else []))
+
+        run = subprocess.run(
+            [str(app)], cwd=build_dir, env=env, capture_output=True, text=True
+        )
+        self.assertEqual(
+            run.returncode,
+            0,
+            f"driver failed:\nstdout: {run.stdout}\nstderr: {run.stderr}",
+        )
+        traces = list(trace_dir.glob("*.clltk_trace"))
+        self.assertTrue(len(traces) > 0, f"no trace files produced in {trace_dir}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tracing_library/CMakeLists.txt
+++ b/tracing_library/CMakeLists.txt
@@ -124,6 +124,9 @@ foreach(LIB_NAME clltk_tracing_static clltk_tracing_shared)
         target_link_options(${LIB_NAME}
             PRIVATE
                 -Wl,--gc-sections
+                # Fail the build on any linker warning (e.g. "creating
+                # DT_TEXTREL"); empty under sanitizers. See Sanitizers.cmake.
+                ${CLLTK_FATAL_LINKER_WARNINGS}
         )
     endif()
 endforeach()

--- a/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
+++ b/tracing_library/include/CommonLowLevelTracingKit/tracing/_user_tracing.h
@@ -128,7 +128,15 @@ _CLLTK_EXTERN_C_END
  * translation unit ("causes a section type conflict"). Assembler-emitted data
  * never joins a COMDAT group. The constraint/operand pair to print a bare
  * symbol address differs per target (each validated with -fPIC/-pie -Werror
- * at -O0..-O2). */
+ * at -O0..-O2).
+ *
+ * The section is emitted writable ("aw"): its entries are absolute pointers
+ * that the dynamic linker must relocate at load time. A read-only section
+ * ("a") would force those relocations onto a read-only page, producing a text
+ * relocation (DT_TEXTREL) that -fPIC cannot avoid and that PIE/hardened
+ * targets (e.g. AArch64) reject. Writable places them in the data segment as
+ * ordinary RELATIVE relocations -- matching how the compiler already handles
+ * the sibling _clltk_tracebuffer_handler_ptr section. */
 #if defined(__aarch64__)
 #define _CLLTK_ASM_SYM_CONSTRAINT "S"
 #define _CLLTK_ASM_SYM_OPERAND(_N_) "%c" _N_
@@ -141,7 +149,7 @@ _CLLTK_EXTERN_C_END
 #endif
 
 #define _CLLTK_EMIT_META_PTR(_BUFFER_, _META_, _OFFSET_)                                         \
-	__asm__(".pushsection _clltk_" #_BUFFER_ "_metaptr,\"a\"\n\t"                                \
+	__asm__(".pushsection _clltk_" #_BUFFER_ "_metaptr,\"aw\"\n\t"                               \
 			".balign " _CLLTK_STR(                                                               \
 				__SIZEOF_POINTER__) "\n\t"                                                       \
 									".dc.a " _CLLTK_ASM_SYM_OPERAND(                             \


### PR DESCRIPTION
## Problem

A tracepoint compiled **into a shared library** (a plugin/driver `.so`) expands `_CLLTK_EMIT_META_PTR`, which emits absolute pointer pairs into the `_clltk_<buffer>_metaptr` section. That section was flagged read-only (`"a"`), so on a PIC/PIE object the dynamic linker must patch a read-only page at load time — a **text relocation (`DT_TEXTREL`)**. `-fPIC` cannot avoid it (the relocation is structurally absolute), PIE/hardened targets such as AArch64 reject it at load time, and packaging QA (`do_package_qa`) fails on it.

## Fix

Flag the section writable (`"aw"`). Its pointers then land in the data segment and are applied as ordinary `RELATIVE` relocations — matching how the compiler already emits the sibling `_clltk_tracebuffer_handler_ptr` section. **No API or ABI change**; consumers just recompile against the updated header.

Verified on x86_64 (gcc) and aarch64 (clang/lld): old flag → `DT_TEXTREL`; new flag → clean `RELATIVE` relocations.

## Why CI missed it, and the guards added

The failing shape *was* built in CI, but only ever as a **linker warning** on a green build — nothing inspected the produced binary. Guards so it cannot return:

- **test** — a packaging consumer test builds a shared library against the **installed** headers and asserts the produced `.so` is free of text relocations and an executable stack (the `do_package_qa` check). This is the shape the pre-existing consumer test (an executable) never exercised.
- **ci** — the compiler-compat matrix links a tracepoint-bearing shared object with `-z text` on every compiler and architecture (incl. arm64/s390x under QEMU), so a text-relocation regression is a hard link error.
- **build** — the tracing library and example shared libraries link with `--fatal-warnings` (gated off under sanitizers), so a "creating DT_TEXTREL" linker warning fails the build instead of scrolling past unread.